### PR TITLE
Reduce log default log verbosity

### DIFF
--- a/tests/src/test/resources/log4j2.properties
+++ b/tests/src/test/resources/log4j2.properties
@@ -25,7 +25,7 @@ appender.out.name = out
 appender.out.layout.type = PatternLayout
 appender.out.layout.pattern = [%30.30t] %-30.30c{1} %-5p %m%n
 
-rootLogger.level = DEBUG
+rootLogger.level = INFO
 rootLogger.appenderRef.file.ref = file
 
 logger.reflections.name = org.reflections
@@ -33,5 +33,5 @@ logger.reflections.level = FATAL
 logger.reflections.appenderRef.file.ref = file
 
 logger.camel-aws.name = org.apache.camel.component.aws
-logger.camel-aws.level  = TRACE
+logger.camel-aws.level  = WARN
 logger.camel-aws.appenderRef.file.ref = file


### PR DESCRIPTION
I don't think we need to be running with this level of debug by default. IMHO, it actually makes harder to find things on the logs unless you know what you are looking for. 