### PR TITLE
Support using an external Kafka for the tests

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -28,6 +28,12 @@ To run the integration tests it is required to:
 mvn clean verify package
 ----
 
+It is also possible to point the tests to use an external Kafka broker. To do so, run the tests using:
+
+----
+mvn -Dkafka.bootstrap.servers=host1:port -Dkafka.instance.type=remote clean verify package
+----
+
 === Try it out locally
 
 You can use Camel Kafka connectors with local Apache Kafka installation.

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/AbstractKafkaTest.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/AbstractKafkaTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kafkaconnector;
+
+import org.apache.camel.kafkaconnector.services.kafka.KafkaService;
+import org.apache.camel.kafkaconnector.services.kafka.KafkaServiceFactory;
+import org.junit.Rule;
+
+public class AbstractKafkaTest {
+    private static final KafkaService KAFKA_SERVICE;
+
+    static {
+        KAFKA_SERVICE = KafkaServiceFactory.createService();
+        KAFKA_SERVICE.initialize();
+    }
+
+    public AbstractKafkaTest() {
+
+    }
+
+    @Rule
+    public KafkaService getKafkaService() {
+        return KAFKA_SERVICE;
+    }
+
+    public KafkaConnectRunner getKafkaConnectRunner() {
+        return new KafkaConnectRunner(getKafkaService().getBootstrapServers());
+    }
+}

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/ContainerUtil.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/ContainerUtil.java
@@ -39,14 +39,14 @@ public final class ContainerUtil {
      * @param container the container to wait for
      */
     public static void waitForInitialization(GenericContainer container) {
-        int retries = 5;
+        int retries = 25;
 
         do {
             boolean state = container.isRunning();
 
             if (!state) {
                 try {
-                    Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+                    Thread.sleep(TimeUnit.SECONDS.toMillis(1));
                 } catch (InterruptedException e) {
                     container.stop();
                     fail("Test interrupted");
@@ -65,14 +65,14 @@ public final class ContainerUtil {
      * @param container the container to wait for
      */
     public static void waitForHttpInitialization(GenericContainer container, int port) {
-        int retries = 5;
+        int retries = 25;
 
         do {
             boolean state = container.isRunning();
 
             if (!state) {
                 try {
-                    Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+                    Thread.sleep(TimeUnit.SECONDS.toMillis(1));
                 } catch (InterruptedException e) {
                     container.stop();
                     fail("Test interrupted");

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/TestCommon.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/TestCommon.java
@@ -29,11 +29,6 @@ import org.slf4j.LoggerFactory;
  */
 public final class TestCommon {
     /**
-     * The default topic for usage during the tests
-     */
-    public static final String DEFAULT_TEST_TOPIC = "mytopic";
-
-    /**
      * The default JMS queue name used during the tests
      */
     public static final String DEFAULT_JMS_QUEUE = "ckc.queue";
@@ -68,5 +63,9 @@ public final class TestCommon {
         LOG.error("Failed to create job for {} with properties {}", name, connectorProps,
                 error);
         fail("Failed to create job for " + name);
+    }
+
+    public static String getDefaultTestTopic(Class<?> clazz) {
+        return clazz.getName();
     }
 }

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafka/ContainerLocalKafkaService.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafka/ContainerLocalKafkaService.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kafkaconnector.services.kafka;
+
+import org.apache.camel.kafkaconnector.ContainerUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.KafkaContainer;
+
+public class ContainerLocalKafkaService implements KafkaService {
+    private static final Logger LOG = LoggerFactory.getLogger(ContainerLocalKafkaService.class);
+    private KafkaContainer kafka = new KafkaContainer().withEmbeddedZookeeper();
+
+    public String getBootstrapServers() {
+        return kafka.getBootstrapServers();
+    }
+
+    @Override
+    public void initialize() {
+        kafka.start();
+
+        ContainerUtil.waitForInitialization(kafka);
+        LOG.info("Kafka bootstrap server running at address {}", kafka.getBootstrapServers());
+    }
+}

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafka/KafkaService.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafka/KafkaService.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kafkaconnector.services.kafka;
+
+import org.junit.rules.MethodRule;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+/**
+ * Provides an interface for any type of Kafka service: remote instances, local container, etc
+ */
+public interface KafkaService extends MethodRule {
+
+    /**
+     * Gets the addresses of the bootstrap servers in the format host1:port,host2:port,etc
+     * @return
+     */
+    String getBootstrapServers();
+
+
+    /**
+     * Perform any initialization necessary
+     */
+    void initialize();
+
+
+    @Override
+    default Statement apply(Statement base, FrameworkMethod frameworkMethod, Object o) {
+        return new Statement() {
+
+            @Override
+            public void evaluate() throws Throwable {
+                try {
+                    base.evaluate();
+                } finally {
+
+                }
+            }
+        };
+    }
+
+}

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafka/KafkaServiceFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafka/KafkaServiceFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kafkaconnector.services.kafka;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class KafkaServiceFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaServiceFactory.class);
+
+    private KafkaServiceFactory() {
+    }
+
+    public static KafkaService createService() {
+        String kafkaRemote = System.getenv("kafka.instance.type");
+        if (kafkaRemote == null || kafkaRemote.equals("local-kafka-container")) {
+            return new ContainerLocalKafkaService();
+        }
+
+        if (kafkaRemote.equals("remote")) {
+            return new RemoteKafkaService();
+        }
+
+        LOG.error("Invalid Kafka instance type: {}. Must be one of 'local-kafka-container' or 'remote",
+                kafkaRemote);
+        throw new UnsupportedOperationException("Invalid Kafka instance type:");
+    }
+}

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafka/RemoteKafkaService.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafka/RemoteKafkaService.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kafkaconnector.services.kafka;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RemoteKafkaService implements KafkaService {
+    private static final Logger LOG = LoggerFactory.getLogger(RemoteKafkaService.class);
+
+    @Override
+    public String getBootstrapServers() {
+        return System.getProperty("kafka.bootstrap.servers");
+    }
+
+    @Override
+    public void initialize() {
+        LOG.info("Kafka bootstrap server running at address {}", getBootstrapServers());
+    }
+}


### PR DESCRIPTION
This decouples the kafka test service from the local container and allows using an
external Kafka instance for testing. It also creates the base work to run the tests
with different different distributions of Kafka (ie.: different Kafka containers, etc)         

As a side effect of this change if also fixes issue #13