### PR TITLE
Convert the embeddable Kafka Connect runner to a JUnit rule

### DIFF
--- a/tests/src/test/java/org/apache/camel/kafkaconnector/AbstractKafkaTest.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/AbstractKafkaTest.java
@@ -19,14 +19,19 @@ package org.apache.camel.kafkaconnector;
 
 import org.apache.camel.kafkaconnector.services.kafka.KafkaService;
 import org.apache.camel.kafkaconnector.services.kafka.KafkaServiceFactory;
+import org.apache.camel.kafkaconnector.services.kafkaconnect.KafkaConnectRunnerService;
+import org.apache.camel.kafkaconnector.services.kafkaconnect.KafkaConnectService;
 import org.junit.Rule;
 
 public class AbstractKafkaTest {
     private static final KafkaService KAFKA_SERVICE;
+    private static final KafkaConnectService KAFKA_CONNECT_RUNNER_SERVICE;
 
     static {
         KAFKA_SERVICE = KafkaServiceFactory.createService();
         KAFKA_SERVICE.initialize();
+
+        KAFKA_CONNECT_RUNNER_SERVICE = new KafkaConnectRunnerService(KAFKA_SERVICE);
     }
 
     public AbstractKafkaTest() {
@@ -38,7 +43,9 @@ public class AbstractKafkaTest {
         return KAFKA_SERVICE;
     }
 
-    public KafkaConnectRunner getKafkaConnectRunner() {
-        return new KafkaConnectRunner(getKafkaService().getBootstrapServers());
+
+    @Rule
+    public KafkaConnectService getKafkaConnectService() {
+        return KAFKA_CONNECT_RUNNER_SERVICE;
     }
 }

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/ContainerUtil.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/ContainerUtil.java
@@ -18,72 +18,15 @@
 package org.apache.camel.kafkaconnector;
 
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.regions.Regions;
-import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
 
-import static org.junit.Assert.fail;
 
 public final class ContainerUtil {
 
     private ContainerUtil() {
-    }
-
-    /**
-     * Wait for the container to be in running state
-     *
-     * @param container the container to wait for
-     */
-    public static void waitForInitialization(GenericContainer container) {
-        int retries = 25;
-
-        do {
-            boolean state = container.isRunning();
-
-            if (!state) {
-                try {
-                    Thread.sleep(TimeUnit.SECONDS.toMillis(1));
-                } catch (InterruptedException e) {
-                    container.stop();
-                    fail("Test interrupted");
-                }
-
-                retries--;
-            } else {
-                break;
-            }
-        } while (retries > 0);
-    }
-
-    /**
-     * Wait for the container to be in running state
-     *
-     * @param container the container to wait for
-     */
-    public static void waitForHttpInitialization(GenericContainer container, int port) {
-        int retries = 25;
-
-        do {
-            boolean state = container.isRunning();
-
-            if (!state) {
-                try {
-                    Thread.sleep(TimeUnit.SECONDS.toMillis(1));
-                } catch (InterruptedException e) {
-                    container.stop();
-                    fail("Test interrupted");
-                }
-
-                retries--;
-            } else {
-                container.waitingFor(Wait.forHttp("/").forPort(port));
-                break;
-            }
-        } while (retries > 0);
     }
 
 

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/TestCommon.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/TestCommon.java
@@ -16,12 +16,8 @@
  */
 package org.apache.camel.kafkaconnector;
 
-import java.util.Properties;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static junit.framework.TestCase.fail;
 
 
 /**
@@ -37,6 +33,11 @@ public final class TestCommon {
      * The default SQS queue name used during the tests
      */
     public static final String DEFAULT_SQS_QUEUE = "ckc";
+
+    /**
+     * The default SQS queue name used during the tests
+     */
+    public static final String DEFAULT_SQS_QUEUE_FOR_SNS = "ckcsns";
 
     /**
      * The default SNS queue name used during the tests
@@ -68,12 +69,6 @@ public final class TestCommon {
     private TestCommon() {
     }
 
-
-    public static void failOnConnectorError(Throwable error, Properties connectorProps, String name) {
-        LOG.error("Failed to create job for {} with properties {}", name, connectorProps,
-                error);
-        fail("Failed to create job for " + name);
-    }
 
     public static String getDefaultTestTopic(Class<?> clazz) {
         return clazz.getName();

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/clients/jms/JMSClient.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/clients/jms/JMSClient.java
@@ -202,6 +202,30 @@ public class JMSClient {
         }
     }
 
+    /**
+     * Sends data to a JMS queue or topic
+     *
+     * @param queue the queue or topic to send data to
+     * @param data  the (string) data to send
+     * @throws JMSException
+     */
+    public void send(final String queue, int data) throws JMSException {
+        MessageProducer producer = null;
+
+        try {
+            producer = session.createProducer(createDestination(queue));
+
+            producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+            producer.setTimeToLive(0);
+
+            Message message = session.createObjectMessage(data);
+
+            producer.send(message);
+        } finally {
+            capturingClose(producer);
+        }
+    }
+
     public static JMSClient createClient(String url) {
         String jmsInstanceType = System.getProperty("jms-service.instance.type");
 

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafka/KafkaService.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafka/KafkaService.java
@@ -45,11 +45,7 @@ public interface KafkaService extends MethodRule {
 
             @Override
             public void evaluate() throws Throwable {
-                try {
                     base.evaluate();
-                } finally {
-
-                }
             }
         };
     }

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafkaconnect/DefaultKafkaConnectPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafkaconnect/DefaultKafkaConnectPropertyFactory.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.camel.kafkaconnector;
+package org.apache.camel.kafkaconnector.services.kafkaconnect;
 
 import java.util.Properties;
 
@@ -26,7 +26,7 @@ import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
  * A set of properties for the Kafka connect runtime that match the standard configuration
  * used for the standalone CLI connect runtime.
  */
-public class DefaultKafkaConnectPropertyFactory implements KafkaConnectPropertyFactory {
+class DefaultKafkaConnectPropertyFactory implements KafkaConnectPropertyFactory {
     private final String bootstrapServer;
 
     /**
@@ -48,7 +48,7 @@ public class DefaultKafkaConnectPropertyFactory implements KafkaConnectPropertyF
         props.put(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG, this.getClass().getResource("/").getPath() + "connect.offsets");
         props.put(StandaloneConfig.OFFSET_COMMIT_INTERVAL_MS_CONFIG, "10000");
         props.put(StandaloneConfig.PLUGIN_PATH_CONFIG, "");
-        props.put(StandaloneConfig.REST_PORT_CONFIG, "9999");
+        props.put(StandaloneConfig.LISTENERS_CONFIG, "http://localhost:9999");
 
         return props;
     }

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafkaconnect/KafkaConnectPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafkaconnect/KafkaConnectPropertyFactory.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.camel.kafkaconnector;
+package org.apache.camel.kafkaconnector.services.kafkaconnect;
 
 import java.util.Properties;
 

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafkaconnect/KafkaConnectRunnerService.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafkaconnect/KafkaConnectRunnerService.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kafkaconnector.services.kafkaconnect;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.kafkaconnector.ConnectorPropertyFactory;
+import org.apache.camel.kafkaconnector.services.kafka.KafkaService;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+import org.jetbrains.annotations.NotNull;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.fail;
+
+public class KafkaConnectRunnerService implements KafkaConnectService {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaConnectRunnerService.class);
+
+    private final KafkaConnectRunner kafkaConnectRunner;
+    private final ExecutorService service = Executors.newCachedThreadPool();
+
+
+    public KafkaConnectRunnerService(KafkaService kafkaService) {
+        Objects.nonNull(kafkaService);
+
+        LOG.debug("Connecting the Kafka Connect Runner to {}", kafkaService.getBootstrapServers());
+        this.kafkaConnectRunner = new KafkaConnectRunner(kafkaService.getBootstrapServers());
+    }
+
+
+    @Override
+    public Statement apply(Statement base, FrameworkMethod frameworkMethod, Object o) {
+        CountDownLatch latch = new CountDownLatch(1);
+        service.submit(() -> kafkaConnectRunner.run(latch));
+
+        try {
+            if (!latch.await(30, TimeUnit.SECONDS)) {
+                LOG.warn("The Kafka Connect Runner timed out while initializing");
+                throw new RuntimeException("The Kafka Connect Runner timed out while initializing");
+            }
+        } catch (InterruptedException e) {
+            LOG.error("The test was interrupted while executing {}", frameworkMethod.getName());
+        }
+
+        return runStatement(base);
+
+    }
+
+    @NotNull
+    private Statement runStatement(Statement base) {
+        return new Statement() {
+
+            @Override
+            public void evaluate() throws Throwable {
+                try {
+                    base.evaluate();
+                } finally {
+                    kafkaConnectRunner.stop();
+                    service.awaitTermination(5, TimeUnit.SECONDS);
+                }
+            }
+        };
+    }
+
+    private void checkInitializationState(KafkaConnectRunner.ConnectorInitState initState) {
+        Objects.nonNull(initState);
+
+        Throwable error = initState.getError();
+        Map<String, String> configs = initState.getConfigs();
+        String name = configs.get(ConnectorConfig.NAME_CONFIG);
+
+        if (error != null) {
+            LOG.error("Failed to create the connector {}: {}", name, error.getMessage(), error);
+            throw new RuntimeException(String.format("Failed to create the connector %s: %s", name,
+                    error.getMessage()), error);
+        } else {
+            if (initState.isCreated()) {
+                LOG.debug("Created and initialized the connector {}", name);
+            } else {
+                LOG.debug("Failed to create connector {}", name);
+                throw new RuntimeException(String.format("Failed to create connector %s", name));
+            }
+        }
+    }
+
+    private void checkInitializationState(KafkaConnectRunner.ConnectorInitState initState, CountDownLatch latch) {
+        try {
+            checkInitializationState(initState);
+        } finally {
+            latch.countDown();
+        }
+    }
+
+
+    @Override
+    public void initializeConnector(ConnectorPropertyFactory propertyFactory) throws ExecutionException, InterruptedException {
+        kafkaConnectRunner.initializeConnector(propertyFactory, this::checkInitializationState);
+    }
+
+    @Override
+    public void initializeConnectorBlocking(ConnectorPropertyFactory propertyFactory) throws ExecutionException, InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        kafkaConnectRunner.initializeConnector(propertyFactory, this::checkInitializationState, latch);
+
+        if (!latch.await(30, TimeUnit.SECONDS)) {
+            fail("The connector did not start within a reasonable time");
+        }
+    }
+}

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafkaconnect/KafkaConnectService.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafkaconnect/KafkaConnectService.java
@@ -15,25 +15,15 @@
  * limitations under the License.
  */
 
-package org.apache.camel.kafkaconnector.services.kafka;
+package org.apache.camel.kafkaconnector.services.kafkaconnect;
 
-import org.apache.camel.kafkaconnector.ContainerUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.KafkaContainer;
+import java.util.concurrent.ExecutionException;
 
-public class ContainerLocalKafkaService implements KafkaService {
-    private static final Logger LOG = LoggerFactory.getLogger(ContainerLocalKafkaService.class);
-    private KafkaContainer kafka = new KafkaContainer().withEmbeddedZookeeper();
+import org.apache.camel.kafkaconnector.ConnectorPropertyFactory;
+import org.junit.rules.MethodRule;
 
-    public String getBootstrapServers() {
-        return kafka.getBootstrapServers();
-    }
+public interface KafkaConnectService extends MethodRule {
 
-    @Override
-    public void initialize() {
-        kafka.start();
-
-        LOG.info("Kafka bootstrap server running at address {}", kafka.getBootstrapServers());
-    }
+    void initializeConnector(ConnectorPropertyFactory propertyFactory) throws ExecutionException, InterruptedException;
+    void initializeConnectorBlocking(ConnectorPropertyFactory propertyFactory) throws ExecutionException, InterruptedException;
 }

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/aws/sqs/CamelAWSSQSPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/aws/sqs/CamelAWSSQSPropertyFactory.java
@@ -50,7 +50,7 @@ class CamelAWSSQSPropertyFactory implements ConnectorPropertyFactory {
         connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
         connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
 
-        String queueUrl = "aws-sqs://" + queue + "?autoCreateQueue=false&accessKey=accesskey&protocol=http&amazonAWSHost="
+        String queueUrl = "aws-sqs://" + queue + "?autoCreateQueue=true&accessKey=accesskey&protocol=http&amazonAWSHost="
                 + amazonConfigs.getProperty(AWSConfigs.AMAZON_AWS_HOST, "localhost");
 
         connectorProps.put("camel.sink.url", queueUrl);


### PR DESCRIPTION
This simplifies the code and makes it possible to reuse the instance for more test cases in the same class. It also simplifies managing the order in which the connect runtime and the test infrastructure need to run.