### PR TITLE
Use artifactId instead of project.name to build colon-less distro paths

### DIFF
--- a/core/src/main/assembly/package.xml
+++ b/core/src/main/assembly/package.xml
@@ -29,8 +29,8 @@
   <includeBaseDirectory>false</includeBaseDirectory>
   <fileSets>
     <fileSet>
-      <directory>${project.basedir}</directory>
-      <outputDirectory>share/doc/${project.name}/</outputDirectory>
+      <directory>${project.basedir}/..</directory>
+      <outputDirectory>share/doc/${project.artifactId}/</outputDirectory>
       <includes>
         <include>README*</include>
         <include>LICENSE*</include>
@@ -39,8 +39,8 @@
       </includes>
     </fileSet>
     <fileSet>
-      <directory>${project.basedir}/config</directory>
-      <outputDirectory>etc/${project.name}</outputDirectory>
+      <directory>${project.basedir}/../config</directory>
+      <outputDirectory>etc/${project.artifactId}</outputDirectory>
       <includes>
         <include>*</include>
       </includes>
@@ -48,7 +48,7 @@
   </fileSets>
   <dependencySets>
     <dependencySet>
-      <outputDirectory>share/java/${project.name}</outputDirectory>
+      <outputDirectory>share/java/${project.artifactId}</outputDirectory>
       <useProjectArtifact>true</useProjectArtifact>
       <useTransitiveFiltering>true</useTransitiveFiltering>
       <excludes>


### PR DESCRIPTION
project.name contains colons and thus 

```
export CLASSPATH="$(find core/target/ -type f -name '*.jar' | grep '\-package' | tr '\n' ':')"
```

used to produce a broken CLASSPATH and the `connect-standalone.sh` commands mentioned in the docs did not work.