### PR TITLE
Added support for using an external JMS broker

### DIFF
--- a/tests/src/test/java/org/apache/camel/kafkaconnector/PropertyUtils.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/PropertyUtils.java
@@ -29,9 +29,14 @@ import org.slf4j.LoggerFactory;
 
 public final class PropertyUtils {
     private static final Logger LOG = LoggerFactory.getLogger(PropertyUtils.class);
+    private static Properties properties = new Properties();
 
     private PropertyUtils() {
 
+    }
+
+    public static Properties getProperties() {
+        return properties;
     }
 
     public static void load() {
@@ -44,8 +49,6 @@ public final class PropertyUtils {
         }
 
         try (InputStream stream = new FileInputStream(fileName)) {
-            Properties properties = new Properties();
-
             properties.load(stream);
 
             System.getProperties().putAll(properties);

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/clients/jms/JMSClient.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/clients/jms/JMSClient.java
@@ -17,7 +17,6 @@
 
 package org.apache.camel.kafkaconnector.clients.jms;
 
-import java.util.Properties;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -29,9 +28,9 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
-import javax.jms.Queue;
 import javax.jms.Session;
 
+import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,21 +40,27 @@ import org.slf4j.LoggerFactory;
 public class JMSClient {
     private static final Logger LOG = LoggerFactory.getLogger(JMSClient.class);
 
-    private final String url;
     private Connection connection;
     private Session session;
 
-    private final Function<String, ? extends ConnectionFactory> connectionFactory;
-    private final Function<String, ? extends Queue> destinationFactory;
+    private ConnectionFactory factory;
 
     public JMSClient(Function<String, ? extends ConnectionFactory> connectionFactory,
-                     Function<String, ? extends Queue> destinationFactory,
                      String url) {
-        this.connectionFactory = connectionFactory;
-        this.destinationFactory = destinationFactory;
-        this.url = url;
+        factory = connectionFactory.apply(url);
     }
 
+    public JMSClient(String className, String url) {
+        Class<? extends ConnectionFactory> clazz;
+        try {
+            clazz = (Class<? extends ConnectionFactory>) Class.forName(className);
+
+            factory = clazz.getConstructor(String.class).newInstance(url);
+        } catch (Exception e) {
+            LOG.error("Unable to create the JMS client classL {}", e.getMessage(), e);
+            Assertions.fail(e);
+        }
+    }
 
     @SuppressWarnings("UnusedReturnValue")
     public static Throwable capturingClose(MessageProducer closeable) {
@@ -113,8 +118,6 @@ public class JMSClient {
         LOG.debug("Starting the JMS client");
 
         try {
-            final ConnectionFactory factory = connectionFactory.apply(url);
-
             LOG.debug("Creating the connection");
             connection = factory.createConnection();
             LOG.debug("Connection created successfully");
@@ -146,7 +149,14 @@ public class JMSClient {
     }
 
     private Destination createDestination(final String destinationName) {
-        return destinationFactory.apply(destinationName);
+        try {
+            return session.createQueue(destinationName);
+        } catch (JMSException e) {
+            Assertions.fail(e.getMessage());
+
+            // unreachable
+            return null;
+        }
     }
 
 
@@ -225,49 +235,4 @@ public class JMSClient {
             capturingClose(producer);
         }
     }
-
-    public static JMSClient createClient(String url) {
-        String jmsInstanceType = System.getProperty("jms-service.instance.type");
-
-        if (jmsInstanceType == null || jmsInstanceType.equals("local-dispatch-router-container")) {
-            return new JMSClient(org.apache.qpid.jms.JmsConnectionFactory::new,
-                    org.apache.qpid.jms.JmsQueue::new, url);
-        }
-
-        if (jmsInstanceType.equals("local-artemis-container")) {
-            return new JMSClient(
-                    org.apache.activemq.ActiveMQConnectionFactory::new,
-                    org.apache.activemq.command.ActiveMQQueue::new,
-                    url);
-        }
-
-        LOG.error("Invalid JMS instance type: {}. Must be one of 'local-artemis-container' or 'local-dispatch-router-container",
-                jmsInstanceType);
-        throw new UnsupportedOperationException("Invalid JMS instance type:");
-    }
-
-    public static Properties getConnectionProperties(String url) {
-        Properties properties = new Properties();
-
-        String jmsInstanceType = System.getProperty("jms-service.instance.type");
-
-        if (jmsInstanceType == null || jmsInstanceType.equals("local-dispatch-router-container")) {
-            properties.put("camel.component.sjms2.connection-factory", "#class:org.apache.qpid.jms.JmsConnectionFactory");
-            properties.put("camel.component.sjms2.connection-factory.remoteURI", url);
-
-            return properties;
-        }
-
-        if (jmsInstanceType.equals("local-artemis-container")) {
-            properties.put("camel.component.sjms2.connection-factory", "#class:org.apache.activemq.ActiveMQConnectionFactory");
-            properties.put("camel.component.sjms2.connection-factory.brokerURL", url);
-
-            return properties;
-        }
-
-        LOG.error("Invalid JMS instance type: {}. Must be one of 'local-artemis-container' or 'local-dispatch-router-container",
-                jmsInstanceType);
-        throw new UnsupportedOperationException("Invalid JMS instance type:");
-    }
-
 }

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/jms/ContainerLocalService.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/jms/ContainerLocalService.java
@@ -20,37 +20,41 @@ package org.apache.camel.kafkaconnector.services.jms;
 import java.util.Properties;
 
 import org.apache.camel.kafkaconnector.clients.jms.JMSClient;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public interface JMSService extends BeforeAllCallback {
+/**
+ * A specialized container that can be used to create Apache Artemis broker
+ * instances.
+ */
+public class ContainerLocalService implements JMSService {
+    private static final Logger LOG = LoggerFactory.getLogger(ContainerLocalService.class);
 
-    /**
-     * Gets the connection properties for accessing the service
-     * @return
-     */
-    Properties getConnectionProperties();
+    private final JMSContainer container;
 
-    /**
-     * Get the appropriate client for the service
-     * @return
-     */
-    JMSClient getClient();
+    public ContainerLocalService(JMSContainer container) {
+        this.container = container;
 
-    /**
-     * Gets the default endpoint for the JMS service (ie.: amqp://host:port, or tcp://host:port, etc)
-     * @return the endpoint URL as a string in the specific format used by the service
-     */
-    String getDefaultEndpoint();
-
-    /**
-     * Perform any initialization necessary
-     */
-    void initialize();
-
+        container.start();
+    }
 
     @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        initialize();
+    public Properties getConnectionProperties() {
+        return container.getConnectionProperties();
+    }
+
+    @Override
+    public JMSClient getClient() {
+        return container.getClient();
+    }
+
+    @Override
+    public String getDefaultEndpoint() {
+        return container.getDefaultEndpoint();
+    }
+
+    @Override
+    public void initialize() {
+        LOG.info("JMS broker running at address {}", container.getDefaultEndpoint());
     }
 }

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/jms/JMSContainer.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/jms/JMSContainer.java
@@ -20,37 +20,32 @@ package org.apache.camel.kafkaconnector.services.jms;
 import java.util.Properties;
 
 import org.apache.camel.kafkaconnector.clients.jms.JMSClient;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.images.builder.ImageFromDockerfile;
 
-public interface JMSService extends BeforeAllCallback {
+public abstract class JMSContainer extends GenericContainer {
+
+
+    public JMSContainer(ImageFromDockerfile dockerfile) {
+        super(dockerfile);
+    }
 
     /**
      * Gets the connection properties for accessing the service
      * @return
      */
-    Properties getConnectionProperties();
+    public abstract Properties getConnectionProperties();
+
 
     /**
-     * Get the appropriate client for the service
+     * Get a client that can access the container
      * @return
      */
-    JMSClient getClient();
+    public abstract JMSClient getClient();
 
     /**
-     * Gets the default endpoint for the JMS service (ie.: amqp://host:port, or tcp://host:port, etc)
-     * @return the endpoint URL as a string in the specific format used by the service
+     * Gets the end point URL used exchanging messages through the default acceptor port
+     * @return the end point URL as a string
      */
-    String getDefaultEndpoint();
-
-    /**
-     * Perform any initialization necessary
-     */
-    void initialize();
-
-
-    @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        initialize();
-    }
+    public abstract String getDefaultEndpoint();
 }

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/jms/JMSServiceFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/jms/JMSServiceFactory.java
@@ -30,14 +30,18 @@ public final class JMSServiceFactory {
         String jmsInstanceType = System.getProperty("jms-service.instance.type");
 
         if (jmsInstanceType == null || jmsInstanceType.equals("local-dispatch-router-container")) {
-            return new QpidDispatchRouterService();
+            return new ContainerLocalService(new QpidDispatchRouterContainer());
         }
 
         if (jmsInstanceType.equals("local-artemis-container")) {
-            return new ArtemisService();
+            return new ContainerLocalService(new ArtemisContainer());
         }
 
-        LOG.error("Invalid JMS instance type: {}. Must be one of 'local-artemis-container' or 'local-dispatch-router-container",
+        if (jmsInstanceType.equals("remote")) {
+            return new RemoteJMSService();
+        }
+
+        LOG.error("Invalid JMS instance type: {}. Must be one of 'remote', 'local-artemis-container' or 'local-dispatch-router-container",
                 jmsInstanceType);
         throw new UnsupportedOperationException("Invalid JMS instance type:");
     }

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/jms/QpidDispatchRouterContainer.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/jms/QpidDispatchRouterContainer.java
@@ -17,14 +17,17 @@
 
 package org.apache.camel.kafkaconnector.services.jms;
 
+import java.util.Properties;
+
+import org.apache.camel.kafkaconnector.clients.jms.JMSClient;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
-public class QpidDispatchRouterService extends JMSService {
+public class QpidDispatchRouterContainer extends JMSContainer {
     private static final int DEFAULT_AMQP_PORT = 5672;
 
 
-    public QpidDispatchRouterService() {
+    public QpidDispatchRouterContainer() {
         super(new ImageFromDockerfile("qpid-dispatch:ckc", false)
                 .withFileFromClasspath("Dockerfile",
                         "org/apache/camel/kafkaconnector/services/jms/qpid-dispatch-router/Dockerfile"));
@@ -55,5 +58,20 @@ public class QpidDispatchRouterService extends JMSService {
     @Override
     public String getDefaultEndpoint() {
         return getAMQPEndpoint();
+    }
+
+    @Override
+    public Properties getConnectionProperties() {
+        Properties properties = new Properties();
+
+        properties.put("camel.component.sjms2.connection-factory", "#class:org.apache.qpid.jms.JmsConnectionFactory");
+        properties.put("camel.component.sjms2.connection-factory.remoteURI", getDefaultEndpoint());
+
+        return properties;
+    }
+
+    @Override
+    public JMSClient getClient() {
+        return new JMSClient(org.apache.qpid.jms.JmsConnectionFactory::new, getDefaultEndpoint());
     }
 }

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/jms/RemoteJMSService.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/jms/RemoteJMSService.java
@@ -19,38 +19,35 @@ package org.apache.camel.kafkaconnector.services.jms;
 
 import java.util.Properties;
 
+import org.apache.camel.kafkaconnector.PropertyUtils;
 import org.apache.camel.kafkaconnector.clients.jms.JMSClient;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
-public interface JMSService extends BeforeAllCallback {
-
-    /**
-     * Gets the connection properties for accessing the service
-     * @return
-     */
-    Properties getConnectionProperties();
-
-    /**
-     * Get the appropriate client for the service
-     * @return
-     */
-    JMSClient getClient();
-
-    /**
-     * Gets the default endpoint for the JMS service (ie.: amqp://host:port, or tcp://host:port, etc)
-     * @return the endpoint URL as a string in the specific format used by the service
-     */
-    String getDefaultEndpoint();
-
-    /**
-     * Perform any initialization necessary
-     */
-    void initialize();
+public class RemoteJMSService implements JMSService {
 
 
     @Override
-    default void beforeAll(ExtensionContext extensionContext) throws Exception {
-        initialize();
+    public void initialize() {
+        // NO-OP
+    }
+
+    @Override
+    public Properties getConnectionProperties() {
+        return PropertyUtils.getProperties();
+    }
+
+    @Override
+    public String getDefaultEndpoint() {
+        return System.getProperty("jms.broker.address");
+    }
+
+    @Override
+    public JMSClient getClient() {
+        String tmpConnectionFactory = System.getProperty("camel.component.sjms2.connection-factory");
+
+        String connectionFactory = tmpConnectionFactory.replace("#class:", "");
+
+        return new JMSClient(connectionFactory, getDefaultEndpoint());
+
+
     }
 }

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/jms/CamelSinkJMSITCase.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/jms/CamelSinkJMSITCase.java
@@ -37,9 +37,9 @@ import org.apache.camel.kafkaconnector.services.jms.JMSServiceFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.junit.Assert.fail;
@@ -53,7 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class CamelSinkJMSITCase extends AbstractKafkaTest {
     private static final Logger LOG = LoggerFactory.getLogger(CamelSinkJMSITCase.class);
 
-    @Container
+    @RegisterExtension
     public JMSService jmsService = JMSServiceFactory.createService();
 
     private int received;
@@ -89,7 +89,7 @@ public class CamelSinkJMSITCase extends AbstractKafkaTest {
     @Timeout(90)
     public void testBasicSendReceive() {
         try {
-            Properties connectionProperties = JMSClient.getConnectionProperties(jmsService.getDefaultEndpoint());
+            Properties connectionProperties = jmsService.getConnectionProperties();
 
             ConnectorPropertyFactory testProperties = new CamelJMSPropertyFactory(1,
                     TestCommon.getDefaultTestTopic(this.getClass()),
@@ -128,7 +128,7 @@ public class CamelSinkJMSITCase extends AbstractKafkaTest {
         JMSClient jmsClient = null;
 
         try {
-            jmsClient = JMSClient.createClient(jmsService.getDefaultEndpoint());
+            jmsClient = jmsService.getClient();
 
             jmsClient.start();
 


### PR DESCRIPTION
Along with the previous PR this allows to configure the test to use an external JMS broker for testing. This gives more flexibility on the testing without having to change the code. 

```
jms-service.instance.type=remote
jms.broker.address=amqp://url.to.a.broker:31672
# ... other settings
```
