### PR TITLE
fix(docs): replace anchor syntax for placeholder

### DIFF
--- a/docs/modules/ROOT/pages/try-it-out-locally.adoc
+++ b/docs/modules/ROOT/pages/try-it-out-locally.adoc
@@ -64,7 +64,7 @@ $KAFKA_HOME/bin/kafka-console-producer.sh --broker-list localhost:9092 --topic m
 
 For the following examples you need to fetch the `camel-kafka-connector` project and https://github.com/apache/camel-kafka-connector/blob/master/README.adoc#build-the-project[build] it locally by running `./mvnw package` from the root of the project. Look into the `config` and `examples` directories for the configuration files (`*.properties`) of the examples showcased here.
 
-First you need to set the `CLASSPATH` environment variable to include the `jar` files from the `core/target/camel-kafka-connector-<<version>>-package/share/java/` directory. On UNIX systems this can be done by running:
+First you need to set the `CLASSPATH` environment variable to include the `jar` files from the `core/target/camel-kafka-connector-[version]-package/share/java/` directory. On UNIX systems this can be done by running:
 
 [source,bash]
 ----


### PR DESCRIPTION
The `<<...>>` syntax triggers asciidoctor to render an link to the
anchor tag, which is detected by the link checker in the build and the
build fails. This uses the `[...]` syntax to denote a placeholder
instead.