### PR TITLE
Binded itests to test phase to better accommodate github actions disk…

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -292,6 +292,7 @@
                     <executions>
                         <execution>
                             <id>integration-test</id>
+                            <phase>test</phase>
                             <goals>
                                 <goal>integration-test</goal>
                                 <goal>verify</goal>


### PR DESCRIPTION
… space limits.

(i.e. avoid the package phase and to package 300+ different camel kafka connectos)