### PR TITLE
Improve documentation for the about section

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -4,4 +4,4 @@ Camel Kafka Connector allows you to use all Camel xref:components::index.adoc[co
 
 To get started try it out xref:try-it-out-locally.adoc[locally] or on xref:try-it-out-on-openshift-with-strimzi.adoc[OpenShift cluster] with https://strimzi.io/[Strimzi].
 
-For more information join the community on the [Camel Users mailing list](/community/mailing-list/) or chat on [Gitter chat](https://gitter.im/apache/camel-kafka-connector) and have a look at the [Camel Kafka Connector GitHub repository](https://github.com/apache/camel-kafka-connector/).
+For more information join the community on the https://camel.apache.org/community/mailing-list/[Camel Users mailing list] or chat on https://gitter.im/apache/camel-kafka-connector[Gitter chat] and have a look at the https://github.com/apache/camel-kafka-connector/[Camel Kafka Connector GitHub repository].

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,5 +1,7 @@
 = About Apache Camel Kafka Connector
 
-Camel Kafka Connector allows you to use all Camel xref:components::index.adoc[components] within the http://kafka.apache.org/documentation/#connect[Kafka Connect].
+Camel Kafka Connector allows you to use all Camel xref:components::index.adoc[components] as http://kafka.apache.org/documentation/#connect[Kafka Connect] connectors, which as result expands Kafka Connect compatibility to include all Camel components to be used in Kafka ecosystem.  
 
 To get started try it out xref:try-it-out-locally.adoc[locally] or on xref:try-it-out-on-openshift-with-strimzi.adoc[OpenShift cluster] with https://strimzi.io/[Strimzi].
+
+For more information join the community on the [Camel Users mailing list](/community/mailing-list/) or chat on [Gitter chat](https://gitter.im/apache/camel-kafka-connector) and have a look at the [Camel Kafka Connector GitHub repository](https://github.com/apache/camel-kafka-connector/).


### PR DESCRIPTION
* The about section currently doesn't provide much brief on the **camel-kafka-connector**  hence I have modified the documentation to include a better brief on the same.