### PR TITLE
Test code fixes for the auto-generated connectors

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -97,7 +97,6 @@
             <artifactId>camel-debezium-common</artifactId>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -273,6 +273,12 @@
                 <artifactId>commons-io</artifactId>
                 <version>${version.commons-io}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-client</artifactId>
+                <version>${activemq.version}</version>
+                <scope>test</scope>
+            </dependency>
 
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -47,10 +47,10 @@
     <modules>
         <module>parent</module>
         <module>core</module>
-        <module>tests</module>
         <module>buildingtools</module>
         <module>tooling</module>
         <module>connectors</module>
+        <module>tests</module>
     </modules>
 
     <developers>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -271,9 +271,12 @@
                     images used when running the tests w/ those containers
                     - java.util.logging.manager sets the logging manager used in GlassFish to the log4j one. GlassFish
                     is used by the rest API of the Kafka Connect.
+                    - com.datastax.driver.FORCE_NIO=true prevents the ClassCastException from
+                    io.netty.channel.epoll.EpollEventLoopGroup cannot be cast to io.netty.channel.EventLoopGroup
+                    probably caused by a netty incompatibility somewhere
 
                      -->
-                    <argLine>-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager -Dproject.basedir=${project.basedir}/.. -Dcom.amazonaws.sdk.disableCbor=true -Ditest.strimzi.container.image=${itest.strimzi.container.image} -Ditest.zookeeper.container.image=${itest.zookeeper.container.image}</argLine>
+                    <argLine>-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager -Dcom.datastax.driver.FORCE_NIO=true -Dproject.basedir=${project.basedir}/.. -Dcom.amazonaws.sdk.disableCbor=true -Ditest.strimzi.container.image=${itest.strimzi.container.image} -Ditest.zookeeper.container.image=${itest.zookeeper.container.image}</argLine>
                     <skipTests>${skipIntegrationTests}</skipTests>
                 </configuration>
             </plugin>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -41,8 +41,9 @@
     </properties>
     <dependencies>
         <!--
-        See the comment on the PluginPathHelper class for details about why
-        the scope is set as provided for the connectors
+        This one is (temporarily) needed for providing supporting classes for the
+        ConnectRecordValueToMapTransformer - which is needed to properly convert record formats from
+        ElasticSearch to Kafka
         -->
         <dependency>
             <groupId>org.apache.camel.kafkaconnector</groupId>
@@ -50,18 +51,7 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.camel.kafkaconnector</groupId>
-            <artifactId>camel-sjms2-kafka-connector</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel.kafkaconnector</groupId>
-            <artifactId>camel-aws-s3-kafka-connector</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-telegram</artifactId>
@@ -83,6 +73,10 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-elasticsearch-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-aws-s3</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
@@ -245,6 +239,12 @@
         <dependency>
             <groupId>org.apache.qpid</groupId>
             <artifactId>qpid-jms-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>activemq-client</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/ConnectorPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/ConnectorPropertyFactory.java
@@ -21,9 +21,7 @@ import java.util.Properties;
 
 /**
  * An interface for producing different types of connector properties that match
- * an specific type of connector in test. Examples of runtime equivalent for this
- * file are the CamelSinkConnector.properties and the CamelSourceConnector.properties
- * files
+ * an specific type of connector in test.
  */
 public interface ConnectorPropertyFactory {
 

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/PluginPathHelper.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/PluginPathHelper.java
@@ -79,7 +79,7 @@ public final class PluginPathHelper {
     }
 
     private static List<String> findPlugins() {
-        return findPlugins("core", "connectors/camel-sjms2-kafka-connector");
+        return findPlugins("core");
     }
 
     /*

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafka/EmbeddedKafkaService.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafka/EmbeddedKafkaService.java
@@ -47,7 +47,7 @@ public class EmbeddedKafkaService implements KafkaService {
 
         String pluginPaths = PluginPathHelper.pluginPaths();
 
-        LOG.info("Adding the following directories to the plugin path: {}", pluginPaths);
+        LOG.info("Adding the returned directories to the plugin path. This may take A VERY long time to complete");
         workerProps.put(WorkerConfig.PLUGIN_PATH_CONFIG, pluginPaths);
 
         LOG.info("Building the embedded Kafka connect instance");

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/aws/sns/CamelAWSSNSPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/aws/sns/CamelAWSSNSPropertyFactory.java
@@ -43,10 +43,10 @@ class CamelAWSSNSPropertyFactory implements ConnectorPropertyFactory {
     @Override
     public Properties getProperties() {
         Properties connectorProps = new Properties();
-        connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelAWSSNSSinkConnector");
+        connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelAwssnsSinkConnector");
         connectorProps.put("tasks.max", String.valueOf(tasksMax));
 
-        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.CamelSinkConnector");
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.awssns.CamelAwssnsSinkConnector");
         connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
         connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
 

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/aws/sns/CamelAWSSNSPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/aws/sns/CamelAWSSNSPropertyFactory.java
@@ -56,12 +56,12 @@ class CamelAWSSNSPropertyFactory implements ConnectorPropertyFactory {
         connectorProps.put("camel.sink.url", queueUrl);
         connectorProps.put("topics", topic);
 
-        connectorProps.put("camel.component.aws-sns.configuration.access-key",
+        connectorProps.put("camel.component.aws-sns.accessKey",
                 amazonConfigs.getProperty(AWSConfigs.ACCESS_KEY, ""));
-        connectorProps.put("camel.component.aws-sns.configuration.secret-key",
+        connectorProps.put("camel.component.aws-sns.secretKey",
                 amazonConfigs.getProperty(AWSConfigs.SECRET_KEY, ""));
 
-        connectorProps.put("camel.component.aws-sns.configuration.region",
+        connectorProps.put("camel.component.aws-sns.region",
             amazonConfigs.getProperty(AWSConfigs.REGION, ""));
 
         connectorProps.put("camel.component.aws-sns.configuration", "#class:"

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/aws/sqs/CamelAWSSQSPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/aws/sqs/CamelAWSSQSPropertyFactory.java
@@ -45,10 +45,10 @@ class CamelAWSSQSPropertyFactory implements ConnectorPropertyFactory {
     public Properties getProperties() {
         Properties connectorProps = new Properties();
 
-        connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelAWSSQSSinkConnector");
+        connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelAwssqsSinkConnector");
         connectorProps.put("tasks.max", String.valueOf(tasksMax));
 
-        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.CamelSinkConnector");
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.awssqs.CamelAwssqsSinkConnector");
         connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
         connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
 

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/aws/sqs/CamelAWSSQSPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/aws/sqs/CamelAWSSQSPropertyFactory.java
@@ -74,12 +74,12 @@ class CamelAWSSQSPropertyFactory implements ConnectorPropertyFactory {
         connectorProps.put("camel.sink.url", queueUrl);
         connectorProps.put("topics", topic);
 
-        connectorProps.put("camel.component.aws-sqs.configuration.access-key",
+        connectorProps.put("camel.component.aws-sqs.accessKey",
                 amazonConfigs.getProperty(AWSConfigs.ACCESS_KEY, ""));
-        connectorProps.put("camel.component.aws-sqs.configuration.secret-key",
+        connectorProps.put("camel.component.aws-sqs.secretKey",
                 amazonConfigs.getProperty(AWSConfigs.SECRET_KEY, ""));
 
-        connectorProps.put("camel.component.aws-sqs.configuration.region", region);
+        connectorProps.put("camel.component.aws-sqs.region", region);
 
         return connectorProps;
     }

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/cassandra/CamelCassandraPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/cassandra/CamelCassandraPropertyFactory.java
@@ -40,10 +40,10 @@ public class CamelCassandraPropertyFactory implements ConnectorPropertyFactory {
     @Override
     public Properties getProperties() {
         Properties connectorProps = new Properties();
-        connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelCassandraQLSinkConnector");
+        connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelCqlSinkConnector");
         connectorProps.put("tasks.max", String.valueOf(tasksMax));
 
-        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.CamelSinkConnector");
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.cql.CamelCqlSinkConnector");
         connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
         connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
 

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/elasticsearch/CamelElasticSearchPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/elasticsearch/CamelElasticSearchPropertyFactory.java
@@ -64,7 +64,7 @@ public class CamelElasticSearchPropertyFactory implements ConnectorPropertyFacto
         connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelElasticSearchSinkConnector");
         connectorProps.put("tasks.max", String.valueOf(tasksMax));
 
-        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.CamelSinkConnector");
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.elasticsearchrest.CamelElasticsearchrestSinkConnector");
         connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
         connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
 

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/elasticsearch/transforms/ConnectRecordValueToMapTransformer.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/elasticsearch/transforms/ConnectRecordValueToMapTransformer.java
@@ -44,7 +44,7 @@ public class ConnectRecordValueToMapTransformer<R extends ConnectRecord<R>> impl
 
         targetMap.put(key, value);
         return r.newRecord(r.topic(), r.kafkaPartition(), null, r.key(),
-                SchemaHelper.buildSchemaBuilderForType(value), targetMap, r.timestamp());
+                 SchemaHelper.buildSchemaBuilderForType(value), targetMap, r.timestamp());
     }
 
     @Override

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/file/CamelFilePropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/file/CamelFilePropertyFactory.java
@@ -39,7 +39,7 @@ class CamelFilePropertyFactory implements ConnectorPropertyFactory {
         connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelFileSinkConnector");
         connectorProps.put("tasks.max", String.valueOf(tasksMax));
 
-        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.CamelSinkConnector");
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.file.CamelFileSinkConnector");
         connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
         connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
 

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/http/CamelHTTPPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/http/CamelHTTPPropertyFactory.java
@@ -39,7 +39,7 @@ class CamelHTTPPropertyFactory implements ConnectorPropertyFactory {
         connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelHttpSinkConnector");
         connectorProps.put("tasks.max", String.valueOf(tasksMax));
 
-        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.CamelSinkConnector");
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.http.CamelHttpSinkConnector");
         connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
         connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
 

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/jms/CamelJMSPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/jms/CamelJMSPropertyFactory.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.camel.kafkaconnector.ConnectorPropertyFactory;
-import org.apache.camel.kafkaconnector.sjms2.CamelSjms2SinkConnectorConfig;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 
 
@@ -53,7 +52,7 @@ class CamelJMSPropertyFactory implements ConnectorPropertyFactory {
         connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.sjms2.CamelSjms2SinkConnector");
         connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
         connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
-        connectorProps.put(CamelSjms2SinkConnectorConfig.CAMEL_SINK_SJMS2_PATH_DESTINATION_NAME_CONF, queue);
+        connectorProps.put("camel.sink.path.destinationName", queue);
         connectorProps.put("topics", topic);
 
         Set<Map.Entry<Object, Object>> set = connectionProperties.entrySet();

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/source/aws/kinesis/CamelAWSKinesisPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/source/aws/kinesis/CamelAWSKinesisPropertyFactory.java
@@ -56,12 +56,11 @@ class CamelAWSKinesisPropertyFactory implements ConnectorPropertyFactory {
         String sourceUrl = "aws-kinesis://" + streamName;
         connectorProps.put("camel.source.url", sourceUrl);
 
-
-        connectorProps.put("camel.component.aws-kinesis.configuration.access-key",
+        connectorProps.put("camel.component.aws-kinesis.accessKey",
                 amazonConfigs.getProperty(AWSConfigs.ACCESS_KEY, ""));
-        connectorProps.put("camel.component.aws-kinesis.configuration.secret-key",
+        connectorProps.put("camel.component.aws-kinesis.secretKey",
                 amazonConfigs.getProperty(AWSConfigs.SECRET_KEY, ""));
-        connectorProps.put("camel.component.aws-kinesis.configuration.region",
+        connectorProps.put("camel.component.aws-kinesis.region",
                 amazonConfigs.getProperty(AWSConfigs.REGION, ""));
 
         connectorProps.put("camel.component.aws-kinesis.configuration", "#class:"

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/source/aws/kinesis/CamelAWSKinesisPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/source/aws/kinesis/CamelAWSKinesisPropertyFactory.java
@@ -25,7 +25,7 @@ import org.apache.kafka.connect.runtime.ConnectorConfig;
 
 
 /**
- * Creates the set of properties used by a Camel JMS Sink Connector
+ * Creates the set of properties used by a Camel Kinesis Source Connector
  */
 class CamelAWSKinesisPropertyFactory implements ConnectorPropertyFactory {
     private final int tasksMax;
@@ -44,10 +44,10 @@ class CamelAWSKinesisPropertyFactory implements ConnectorPropertyFactory {
     @Override
     public Properties getProperties() {
         Properties connectorProps = new Properties();
-        connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelAWSKinesisSourceConnector");
+        connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelAwskinesisSourceConnector");
         connectorProps.put("tasks.max", String.valueOf(tasksMax));
 
-        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.CamelSourceConnector");
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.awskinesis.CamelAwskinesisSourceConnector");
         connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
         connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
 

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/source/aws/s3/CamelAWSS3PropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/source/aws/s3/CamelAWSS3PropertyFactory.java
@@ -56,11 +56,11 @@ class CamelAWSS3PropertyFactory implements ConnectorPropertyFactory {
         connectorProps.put("camel.source.url", queueUrl);
 
 
-        connectorProps.put("camel.component.aws-s3.configuration.access-key",
+        connectorProps.put("camel.component.aws-s3.accessKey",
                 amazonConfigs.getProperty(AWSConfigs.ACCESS_KEY, ""));
-        connectorProps.put("camel.component.aws-s3.configuration.secret-key",
+        connectorProps.put("camel.component.aws-s3.secretKey",
                 amazonConfigs.getProperty(AWSConfigs.SECRET_KEY, ""));
-        connectorProps.put("camel.component.aws-s3.configuration.region",
+        connectorProps.put("camel.component.aws-s3.region",
                 amazonConfigs.getProperty(AWSConfigs.REGION, ""));
 
         connectorProps.put("camel.component.aws-s3.configuration", "#class:"

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/source/aws/s3/CamelAWSS3PropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/source/aws/s3/CamelAWSS3PropertyFactory.java
@@ -44,7 +44,7 @@ class CamelAWSS3PropertyFactory implements ConnectorPropertyFactory {
     @Override
     public Properties getProperties() {
         Properties connectorProps = new Properties();
-        connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelAWSS3SSourceConnector");
+        connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelAwss3SourceConnector");
 
         connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.awss3.CamelAwss3SourceConnector");
         connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/source/aws/sqs/CamelAWSSQSPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/source/aws/sqs/CamelAWSSQSPropertyFactory.java
@@ -74,11 +74,11 @@ class CamelAWSSQSPropertyFactory implements ConnectorPropertyFactory {
 
         connectorProps.put("camel.source.url", queueUrl);
 
-        connectorProps.put("camel.component.aws-sqs.configuration.access-key",
+        connectorProps.put("camel.component.aws-sqs.accessKey",
                 amazonConfigs.getProperty(AWSConfigs.ACCESS_KEY, ""));
-        connectorProps.put("camel.component.aws-sqs.configuration.secret-key",
+        connectorProps.put("camel.component.aws-sqs.secretKey",
                 amazonConfigs.getProperty(AWSConfigs.SECRET_KEY, ""));
-        connectorProps.put("camel.component.aws-sqs.configuration.region",
+        connectorProps.put("camel.component.aws-sqs.region",
                 amazonConfigs.getProperty(AWSConfigs.REGION, ""));
 
         return connectorProps;

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/source/aws/sqs/CamelAWSSQSPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/source/aws/sqs/CamelAWSSQSPropertyFactory.java
@@ -45,10 +45,10 @@ class CamelAWSSQSPropertyFactory implements ConnectorPropertyFactory {
     @Override
     public Properties getProperties() {
         Properties connectorProps = new Properties();
-        connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelAWSSQSSourceConnector");
+        connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelAwssqsSourceConnector");
         connectorProps.put("tasks.max", String.valueOf(tasksMax));
 
-        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.CamelSourceConnector");
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.awssqs.CamelAwssqsSourceConnector");
         connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
         connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
 

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/source/jms/CamelJMSPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/source/jms/CamelJMSPropertyFactory.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.camel.kafkaconnector.ConnectorPropertyFactory;
-import org.apache.camel.kafkaconnector.sjms2.CamelSjms2SourceConnectorConfig;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 
 
@@ -53,7 +52,7 @@ class CamelJMSPropertyFactory implements ConnectorPropertyFactory {
         connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.sjms2.CamelSjms2SourceConnector");
         connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
         connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
-        connectorProps.put(CamelSjms2SourceConnectorConfig.CAMEL_SOURCE_SJMS2_PATH_DESTINATION_NAME_CONF, queue);
+        connectorProps.put("camel.source.path.destinationName", queue);
         connectorProps.put("camel.source.kafka.topic", topic);
 
         Set<Map.Entry<Object, Object>> set = connectionProperties.entrySet();

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/source/timer/CamelTimerPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/source/timer/CamelTimerPropertyFactory.java
@@ -36,10 +36,10 @@ class CamelTimerPropertyFactory implements ConnectorPropertyFactory {
     @Override
     public Properties getProperties() {
         Properties connectorProps = new Properties();
-        connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelSourceConnector");
+        connectorProps.put(ConnectorConfig.NAME_CONFIG, "CamelTimerSourceConnector");
         connectorProps.put("tasks.max", String.valueOf(tasksMax));
 
-        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.CamelSourceConnector");
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "org.apache.camel.kafkaconnector.timer.CamelTimerSourceConnector");
         connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
         connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
         connectorProps.put("camel.source.url", String.format("timer:kafkaconnector?repeatCount=%d", repeatCount));

--- a/tests/src/test/resources/log4j2.properties
+++ b/tests/src/test/resources/log4j2.properties
@@ -48,6 +48,10 @@ logger.kafka.name = org.apache.kafka
 logger.kafka.level = WARN
 logger.kafka.appenderRef.file.ref = file
 
+logger.kafka-delegating.name = org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader
+logger.kafka-delegating.level = INFO
+logger.kafka-delegating.appenderRef.file.ref = file
+
 logger.glassfish.name = org.glassfish.jersey.internal
 logger.glassfish.level = FATAL
 logger.glassfish.appenderRef.file.ref = file

--- a/tests/src/test/resources/log4j2.properties
+++ b/tests/src/test/resources/log4j2.properties
@@ -51,3 +51,7 @@ logger.kafka.appenderRef.file.ref = file
 logger.glassfish.name = org.glassfish.jersey.internal
 logger.glassfish.level = FATAL
 logger.glassfish.appenderRef.file.ref = file
+
+logger.connector.name = org.apache.camel.kafkaconnector
+logger.connector.level = DEBUG
+logger.connector.appenderRef.file.ref = file


### PR DESCRIPTION
This fixes a couple of errors in tests and adjust the code to work with the new
auto-generated connectors. It fixes most of the DelegatingClassLoader errors 
although one still remain in one scenario: ElasticSearch Rest with Java 8.