### PR TITLE
Adds a manual test for the Camel Slack sink connector

### DIFF
--- a/examples/CamelSlackSinkConnector.properties
+++ b/examples/CamelSlackSinkConnector.properties
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name=CamelSlackSinkConnector
+tasks.max=1
+
+connector.class=org.apache.camel.kafkaconnector.slack.CamelSlackSinkConnector
+value.converter=org.apache.kafka.connect.storage.StringConverter
+key.converter=org.apache.kafka.connect.storage.StringConverter
+
+camel.sink.endpoint.webhookUrl=https://hooks.slack.com/path/to/id
+camel.sink.path.channel=#opensourcetest
+
+topics=my-topic

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -104,6 +104,10 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-timer</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-slack</artifactId>
+        </dependency>
 
         <!-- test scope dependencies -->
         <dependency>

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/PluginPathHelper.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/PluginPathHelper.java
@@ -36,7 +36,8 @@ public final class PluginPathHelper {
         "connectors/camel-aws-sns-kafka-connector", "connectors/camel-aws-sqs-kafka-connector",
         "connectors/camel-aws-s3-kafka-connector", "connectors/camel-aws-kinesis-kafka-connector",
         "connectors/camel-elasticsearch-rest-kafka-connector", "connectors/camel-http-kafka-connector",
-        "connectors/camel-timer-kafka-connector", "connectors/camel-file-kafka-connector"
+        "connectors/camel-timer-kafka-connector", "connectors/camel-file-kafka-connector",
+        "connectors/camel-slack-kafka-connector"
     };
 
     private static class PluginWalker extends DirectoryWalker<String> {

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/slack/CamelSinkSlackITCase.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/slack/CamelSinkSlackITCase.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kafkaconnector.sink.slack;
+
+import java.util.concurrent.ExecutionException;
+
+import org.apache.camel.kafkaconnector.AbstractKafkaTest;
+import org.apache.camel.kafkaconnector.ConnectorPropertyFactory;
+import org.apache.camel.kafkaconnector.TestCommon;
+import org.apache.camel.kafkaconnector.clients.kafka.KafkaClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Integration tests for the JMS sink
+ */
+@Testcontainers
+/* This test is disabled by default because requires manual verification on Slack end.
+
+You need to set 3 system properties to run this test:
+ -Dit.test.slack.enable=true to enable the test
+ -Dit.test.slack.channel=#channel to inform the channel to send the message to
+ -Dit.test.slack.webhookUrl=https://host.slack.com/id/of/the/hook to pass the incoming hook URL to the test
+ */
+@EnabledIfSystemProperty(named = "it.test.slack.enable", matches = "true")
+public class CamelSinkSlackITCase extends AbstractKafkaTest {
+    private static final Logger LOG = LoggerFactory.getLogger(CamelSinkSlackITCase.class);
+    private String slackChannel = System.getProperty("it.test.slack.channel");
+    private String webhookUrl = System.getProperty("it.test.slack.webhookUrl");
+
+
+    private void runTest(ConnectorPropertyFactory connectorPropertyFactory, String message) throws ExecutionException, InterruptedException {
+        connectorPropertyFactory.log();
+        getKafkaConnectService().initializeConnector(connectorPropertyFactory);
+
+        KafkaClient<String, String> kafkaClient = new KafkaClient<>(getKafkaService().getBootstrapServers());
+
+        kafkaClient.produce(TestCommon.getDefaultTestTopic(this.getClass()), message);
+
+
+        LOG.debug("Created the consumer ... About to receive messages");
+    }
+
+    @Test
+    @Timeout(90)
+    public void testBasicSendReceive() {
+        try {
+            ConnectorPropertyFactory connectorPropertyFactory = CamelSlackPropertyFactory
+                    .basic()
+                    .withTopics(TestCommon.getDefaultTestTopic(this.getClass()))
+                    .withChannel(slackChannel)
+                    .withWebhookUrl(webhookUrl);
+
+            runTest(connectorPropertyFactory, "Sink test message sent to Slack from testBasicSendReceive");
+
+        } catch (Exception e) {
+            LOG.error("Slack test failed: {}", e.getMessage(), e);
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    @Timeout(90)
+    public void testBasicSendReceiveWithUrl() {
+        try {
+            ConnectorPropertyFactory connectorPropertyFactory = CamelSlackPropertyFactory
+                    .basic()
+                    .withTopics(TestCommon.getDefaultTestTopic(this.getClass()))
+                    .withUrl(slackChannel)
+                        .append("webhookUrl", webhookUrl)
+                        .buildUrl();
+
+            runTest(connectorPropertyFactory, "Sink test message sent to Slack from testBasicSendReceiveWithUrl");
+
+        } catch (Exception e) {
+            LOG.error("Slack test failed: {}", e.getMessage(), e);
+            fail(e.getMessage());
+        }
+    }
+
+}

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/slack/CamelSlackPropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/slack/CamelSlackPropertyFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kafkaconnector.sink.slack;
+
+import org.apache.camel.kafkaconnector.EndpointUrlBuilder;
+import org.apache.camel.kafkaconnector.SinkConnectorPropertyFactory;
+
+
+/**
+ * Creates the set of properties used by a Camel Slack Sink Connector
+ */
+final class CamelSlackPropertyFactory extends SinkConnectorPropertyFactory<CamelSlackPropertyFactory> {
+    private CamelSlackPropertyFactory() {
+
+    }
+
+    public CamelSlackPropertyFactory withChannel(String channel) {
+        return setProperty("camel.sink.path.channel", channel);
+    }
+
+    public CamelSlackPropertyFactory withWebhookUrl(String webhookUrl) {
+        return setProperty("camel.sink.endpoint.webhookUrl", webhookUrl);
+    }
+
+    public EndpointUrlBuilder<CamelSlackPropertyFactory> withUrl(String channel) {
+        String queueUrl = String.format("slack:%s", channel);
+
+        return new EndpointUrlBuilder<>(this::withSinkUrl, queueUrl);
+    }
+
+    public static CamelSlackPropertyFactory basic() {
+        return new CamelSlackPropertyFactory()
+                .withName("CamelSlackSinkConnector")
+                .withTasksMax(1)
+                .withConnectorClass("org.apache.camel.kafkaconnector.slack.CamelSlackSinkConnector")
+                .withKeyConverterClass("org.apache.kafka.connect.storage.StringConverter")
+                .withValueConverterClass("org.apache.kafka.connect.storage.StringConverter");
+    }
+}


### PR DESCRIPTION
Due to being manual, the test is disabled by default. The PR also includes an example for the Slack sink connector