### PR TITLE
Added Salesforce source connector properties file

### DIFF
--- a/examples/CamelSalesforceSourceConnector.properties
+++ b/examples/CamelSalesforceSourceConnector.properties
@@ -20,14 +20,9 @@ connector.class=org.apache.camel.kafkaconnector.salesforce.CamelSalesforceSource
 key.converter=org.apache.kafka.connect.storage.StringConverter
 value.converter=org.apache.kafka.connect.storage.StringConverter
 
-camel.source.kafka.topic=mytopic
+topics=mytopic
 
-camel.source.url=salesforce:CamelKafkaConnectorTestTopic?
-camel.source.endpoint.notifyForFields=ALL
-camel.source.endpoint.notifyForOperations=ALL
-camel.source.endpoint.sObjectName=Merchandise__c
-camel.source.endpoint.sObjectQuery=SELECT Id, Name FROM Merchandise__c
-camel.source.endpoint.updateTopic=true
+camel.source.url=salesforce:CamelKafkaConnectorTestTopic?notifyForFields=ALL&notifyForOperations=ALL&sObjectName=Merchandise__c&updateTopic=true&sObjectQuery=SELECT Id, Name FROM Merchandise__c
 
 camel.component.salesforce.clientId=<YOUR CLIENT ID HERE>
 camel.component.salesforce.clientSecret=<YOUR CLIENT SECRET HERE>

--- a/examples/CamelSalesforceSourceConnector.properties
+++ b/examples/CamelSalesforceSourceConnector.properties
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name=CamelSalesforceSourceConnector
+connector.class=org.apache.camel.kafkaconnector.CamelSourceConnector
+key.converter=org.apache.kafka.connect.storage.StringConverter
+value.converter=org.apache.kafka.connect.storage.StringConverter
+
+camel.source.kafka.topic=mytopic
+
+camel.source.url=salesforce:CamelKafkaConnectorTestTopic?
+camel.source.endpoint.notifyForFields=ALL
+camel.source.endpoint.notifyForOperations=ALL
+camel.source.endpoint.sObjectName=Merchandise__c
+camel.source.endpoint.sObjectQuery=SELECT Id, Name FROM Merchandise__c
+camel.source.endpoint.updateTopic=true
+
+camel.component.salesforce.clientId=<YOUR CLIENT ID HERE>
+camel.component.salesforce.clientSecret=<YOUR CLIENT SECRET HERE>
+camel.component.salesforce.password=<YOUR PASSWORD HERE>
+camel.component.salesforce.userName=<YOUR USERNAME HERE>

--- a/examples/CamelSalesforceSourceConnector.properties
+++ b/examples/CamelSalesforceSourceConnector.properties
@@ -16,7 +16,7 @@
 #
 
 name=CamelSalesforceSourceConnector
-connector.class=org.apache.camel.kafkaconnector.CamelSourceConnector
+connector.class=org.apache.camel.kafkaconnector.salesforce.CamelSalesforceSourceConnector
 key.converter=org.apache.kafka.connect.storage.StringConverter
 value.converter=org.apache.kafka.connect.storage.StringConverter
 

--- a/examples/CamelSalesforceSourceConnector.properties
+++ b/examples/CamelSalesforceSourceConnector.properties
@@ -24,6 +24,7 @@ topics=mytopic
 
 camel.source.url=salesforce:CamelKafkaConnectorTestTopic?notifyForFields=ALL&notifyForOperations=ALL&sObjectName=Merchandise__c&updateTopic=true&sObjectQuery=SELECT Id, Name FROM Merchandise__c
 
+camel.component.salesforce.loginUrl=<YOUR LOGIN URL HERE>
 camel.component.salesforce.clientId=<YOUR CLIENT ID HERE>
 camel.component.salesforce.clientSecret=<YOUR CLIENT SECRET HERE>
 camel.component.salesforce.password=<YOUR PASSWORD HERE>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -114,6 +114,10 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-slack</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-salesforce</artifactId>
+        </dependency>
 
         <!-- test scope dependencies -->
         <dependency>


### PR DESCRIPTION
Hi, when I was testing this example I get this error,
>[2020-05-03 22:25:15,580] ERROR An exception has occurred before CamelContext startup has finished (org.apache.camel.kafkaconnector.utils.CamelMainSupport:220)
java.lang.IllegalArgumentException: Error configuring property: camel.component.salesforce.password because cannot find component with name salesforce. Make sure you have the component on the classpath
	at org.apache.camel.main.BaseMainSupport.lambda$autoConfigurationFromProperties$15(BaseMainSupport.java:959)
	at org.apache.camel.main.BaseMainSupport.computeProperties(BaseMainSupport.java:1148)
	at org.apache.camel.main.BaseMainSupport.autoConfigurationFromProperties(BaseMainSupport.java:956)
	at org.apache.camel.main.BaseMainSupport.autoconfigure(BaseMainSupport.java:545)
	at org.apache.camel.main.BaseMainSupport.postProcessCamelContext(BaseMainSupport.java:587)
	at org.apache.camel.main.BaseMainSupport.initCamelContext(BaseMainSupport.java:423)
	at org.apache.camel.main.Main.doInit(Main.java:109)
	at org.apache.camel.support.service.ServiceSupport.init(ServiceSupport.java:83)
	at org.apache.camel.support.service.ServiceSupport.start(ServiceSupport.java:112)
	at org.apache.camel.main.MainSupport.run(MainSupport.java:82)
	at org.apache.camel.kafkaconnector.utils.CamelMainSupport$CamelContextStarter.run(CamelMainSupport.java:218)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)

and 
>[2020-05-03 22:25:15,589] ERROR WorkerSourceTask{id=CamelSalesforceSourceConnector-0} Task is being killed and will not recover until manually restarted (org.apache.kafka.connect.runtime.WorkerTask:187)


is this the correct approach? Thanks :)