### PR TITLE
Re-enable Cassandra test using properties

### DIFF
--- a/tests/src/test/java/org/apache/camel/kafkaconnector/clients/cassandra/dao/TestDataDao.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/clients/cassandra/dao/TestDataDao.java
@@ -78,6 +78,15 @@ public class TestDataDao {
         session.execute(statement);
     }
 
+    public void dropTable() {
+        String statement = SchemaBuilder.dropTable(TABLE_NAME)
+                .getQueryString();
+
+        LOG.info("Executing drop table {}", statement);
+
+        session.execute(statement);
+    }
+
     public boolean hasEnoughData(long expected) {
         ResultSet rs = session.execute("select count(*) from test_data");
 

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/cassandra/CamelSinkCassandraITCase.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/cassandra/CamelSinkCassandraITCase.java
@@ -31,8 +31,8 @@ import org.apache.camel.kafkaconnector.clients.cassandra.dao.TestDataDao;
 import org.apache.camel.kafkaconnector.clients.kafka.KafkaClient;
 import org.apache.camel.kafkaconnector.services.cassandra.CassandraService;
 import org.apache.camel.kafkaconnector.services.cassandra.CassandraServiceFactory;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
@@ -64,6 +64,15 @@ public class CamelSinkCassandraITCase extends AbstractKafkaTest {
         testDataDao.createKeySpace();
         testDataDao.useKeySpace();
         testDataDao.createTable();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        cassandraClient = cassandraService.getClient();
+
+        if (testDataDao != null) {
+            testDataDao.dropTable();
+        }
     }
 
     private void putRecords(CountDownLatch latch) {
@@ -110,7 +119,6 @@ public class CamelSinkCassandraITCase extends AbstractKafkaTest {
 
     }
 
-    @Disabled("Known issue")
     @Test
     public void testFetchFromCassandra() throws ExecutionException, InterruptedException {
         String topic = TestCommon.getDefaultTestTopic(this.getClass());


### PR DESCRIPTION
The test was disabled due to github issue #143. This patch re-enables
the test with the required additional logic to make it functional along
with the other tests