### PR TITLE
Removes usage of fixed hostnames in integration tests

### DIFF
--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/aws/AWSKinesisLocalContainerService.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/aws/AWSKinesisLocalContainerService.java
@@ -38,7 +38,7 @@ public class AWSKinesisLocalContainerService extends AWSLocalContainerService<Am
     public String getAmazonHost() {
         final int kinesisPort = 4568;
 
-        return "localhost:" + getContainer().getMappedPort(kinesisPort);
+        return getContainer().getContainerIpAddress() + ":" + getContainer().getMappedPort(kinesisPort);
     }
 
 

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/aws/AWSLocalContainerService.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/aws/AWSLocalContainerService.java
@@ -93,7 +93,7 @@ abstract class AWSLocalContainerService<T> implements AWSService<T> {
     }
 
     protected String getAmazonHost(int port) {
-        return "localhost:" + container.getMappedPort(port);
+        return container.getContainerIpAddress() + ":" + container.getMappedPort(port);
     }
 
     protected String getServiceEndpoint(LocalStackContainer.Service service) {

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/aws/AWSS3LocalContainerService.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/aws/AWSS3LocalContainerService.java
@@ -39,7 +39,7 @@ public class AWSS3LocalContainerService extends AWSLocalContainerService<AmazonS
     public String getAmazonHost() {
         final int s3Port = 4572;
 
-        return "localhost:" + getContainer().getMappedPort(s3Port);
+        return getContainer().getContainerIpAddress() + ":" + getContainer().getMappedPort(s3Port);
     }
 
     @Override

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/elasticsearch/ElasticSearchLocalContainerService.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/elasticsearch/ElasticSearchLocalContainerService.java
@@ -60,7 +60,7 @@ public class ElasticSearchLocalContainerService implements ElasticSearchService 
 
     @Override
     public ElasticSearchClient getClient() {
-        return new ElasticSearchClient("localhost", container.getMappedPort(ELASTIC_SEARCH_PORT),
+        return new ElasticSearchClient(container.getContainerIpAddress(), container.getMappedPort(ELASTIC_SEARCH_PORT),
                 TestCommon.DEFAULT_ELASTICSEARCH_INDEX);
     }
 }

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/jms/ArtemisContainer.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/jms/ArtemisContainer.java
@@ -56,7 +56,7 @@ public class ArtemisContainer extends JMSContainer {
      * @return the end point URL as a string
      */
     public String getAMQPEndpoint() {
-        return String.format("tcp://localhost:%d", getAMQPPort());
+        return String.format("tcp://%s:%d", getContainerIpAddress(), getAMQPPort());
     }
 
 
@@ -74,7 +74,7 @@ public class ArtemisContainer extends JMSContainer {
      * @return the end point URL as a string
      */
     public String getMQTTEndpoint() {
-        return String.format("tcp://localhost:%d", getMQTTPort());
+        return String.format("tcp://%s:%d", getContainerIpAddress(), getMQTTPort());
     }
 
 
@@ -92,7 +92,7 @@ public class ArtemisContainer extends JMSContainer {
      * @return the admin URL as a string
      */
     public String getAdminURL() {
-        return String.format("http://localhost:%d", getAdminPort());
+        return String.format("http://%s:%d", getContainerIpAddress(), getAdminPort());
     }
 
 
@@ -110,7 +110,7 @@ public class ArtemisContainer extends JMSContainer {
      * @return the end point URL as a string
      */
     public String getDefaultEndpoint() {
-        return String.format("tcp://localhost:%d", getDefaultAcceptorPort());
+        return String.format("tcp://%s:%d", getContainerIpAddress(), getDefaultAcceptorPort());
     }
 
 
@@ -128,7 +128,7 @@ public class ArtemisContainer extends JMSContainer {
      * @return the end point URL as a string
      */
     public String getOpenwireEndpoint() {
-        return String.format("tcp://localhost:%d", getOpenwirePort());
+        return String.format("tcp://%s:%d", getContainerIpAddress(), getOpenwirePort());
     }
 
     @Override

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/jms/QpidDispatchRouterContainer.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/jms/QpidDispatchRouterContainer.java
@@ -52,7 +52,7 @@ public class QpidDispatchRouterContainer extends JMSContainer {
      * @return the end point URL as a string
      */
     public String getAMQPEndpoint() {
-        return String.format("amqp://localhost:%d", getAMQPPort());
+        return String.format("amqp://%s:%d", getContainerIpAddress(), getAMQPPort());
     }
 
     @Override

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafka/StrimziContainer.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafka/StrimziContainer.java
@@ -33,7 +33,7 @@ public class StrimziContainer extends GenericContainer<StrimziContainer> {
 
         withEnv("LOG_DIR", "/tmp/logs");
         withExposedPorts(KAFKA_PORT);
-        withEnv("KAFKA_ADVERTISED_LISTENERS", "PLAINTEXT://localhost:9092");
+        withEnv("KAFKA_ADVERTISED_LISTENERS", String.format("PLAINTEXT://%s:9092", getContainerIpAddress()));
         withEnv("KAFKA_LISTENERS", "PLAINTEXT://0.0.0.0:9092");
         withEnv("KAFKA_ZOOKEEPER_CONNECT", "zookeeper:2181");
         withNetwork(network);

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafka/StrimziService.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/services/kafka/StrimziService.java
@@ -39,7 +39,7 @@ public class StrimziService implements KafkaService {
 
     @Override
     public String getBootstrapServers() {
-        return "localhost:" + getKafkaPort();
+        return strimziContainer.getContainerIpAddress() + ":" + getKafkaPort();
     }
 
     @Override

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/http/CamelSinkHTTPITCase.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/http/CamelSinkHTTPITCase.java
@@ -114,7 +114,7 @@ public class CamelSinkHTTPITCase extends AbstractKafkaTest {
     @Timeout(90)
     public void testBasicSendReceive() {
         try {
-            String url = "localhost:" + HTTP_PORT + "/ckc";
+            String url = localServer.getInetAddress().getHostName() + ":" + HTTP_PORT + "/ckc";
 
             ConnectorPropertyFactory connectorPropertyFactory = CamelHTTPPropertyFactory.basic()
                     .withTopics(TestCommon.getDefaultTestTopic(this.getClass()))
@@ -131,7 +131,7 @@ public class CamelSinkHTTPITCase extends AbstractKafkaTest {
     @Timeout(90)
     public void testBasicSendReceiveUsingUrl() {
         try {
-            String hostName = "localhost:" + HTTP_PORT + "/ckc";
+            String hostName = localServer.getInetAddress().getHostName() + ":" + HTTP_PORT + "/ckc";
 
             ConnectorPropertyFactory connectorPropertyFactory = CamelHTTPPropertyFactory.basic()
                     .withTopics(TestCommon.getDefaultTestTopic(this.getClass()))


### PR DESCRIPTION
As an additional bonus of the cleanup, also allows running the 
containers remotely using DOCKER_TLS_VERIFY=0 DOCKER_HOST=tcp://my.docker.host.com:2375