### PR TITLE
Remove core from test plugin path

### DIFF
--- a/tests/src/test/java/org/apache/camel/kafkaconnector/PluginPathHelper.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/PluginPathHelper.java
@@ -32,7 +32,7 @@ public final class PluginPathHelper {
     private static final Logger LOG = LoggerFactory.getLogger(PluginPathHelper.class);
 
     private static final String[] MODULES = {
-        "core", "connectors/camel-sjms2-kafka-connector", "connectors/camel-cql-kafka-connector",
+        "connectors/camel-sjms2-kafka-connector", "connectors/camel-cql-kafka-connector",
         "connectors/camel-aws-sns-kafka-connector", "connectors/camel-aws-sqs-kafka-connector",
         "connectors/camel-aws-s3-kafka-connector", "connectors/camel-aws-kinesis-kafka-connector",
         "connectors/camel-elasticsearch-rest-kafka-connector", "connectors/camel-http-kafka-connector",


### PR DESCRIPTION
Core is not needed on the plugin path since test code now uses the connectors' path