### PR TITLE
Use camel-depencencies to import versions of common libraries like Ja…

### DIFF
--- a/connectors/camel-syslog-kafka-connector/src/main/assembly/package.xml
+++ b/connectors/camel-syslog-kafka-connector/src/main/assembly/package.xml
@@ -37,8 +37,8 @@
       </includes>
     </fileSet>
     <fileSet>
-      <directory><#noparse>${project.basedir}/src/main/docs</#noparse></directory>
-      <outputDirectory><#noparse>docs/</#noparse></outputDirectory>
+      <directory>${project.basedir}/src/main/docs</directory>
+      <outputDirectory>docs/</outputDirectory>
       <includes>
         <include>**/*</include>
       </includes>

--- a/docs/modules/ROOT/pages/connectors.adoc
+++ b/docs/modules/ROOT/pages/connectors.adoc
@@ -2,7 +2,7 @@
 = Supported connectors and documentation
 
 // kafka-connectors list: START
-Number of Camel Kafka connectors: 353 
+Number of Camel Kafka connectors: 350 
 
 [width="100%",cols="6,1,1,1,1",options="header"]
 |===
@@ -123,7 +123,6 @@ Number of Camel Kafka connectors: 353
 | *camel-etcd-keys-kafka-connector* | true | false | xref:connectors/camel-etcd-keys-kafka-sink-connector.adoc[Sink Docs] | 
 | *camel-etcd-stats-kafka-connector* | true | true | xref:connectors/camel-etcd-stats-kafka-sink-connector.adoc[Sink Docs] | xref:connectors/camel-etcd-stats-kafka-source-connector.adoc[Source Docs]
 | *camel-etcd-watch-kafka-connector* | false | true |  | xref:connectors/camel-etcd-watch-kafka-source-connector.adoc[Source Docs]
-| *camel-eventadmin-kafka-connector* | true | true | xref:connectors/camel-eventadmin-kafka-sink-connector.adoc[Sink Docs] | xref:connectors/camel-eventadmin-kafka-source-connector.adoc[Source Docs]
 | *camel-exec-kafka-connector* | true | false | xref:connectors/camel-exec-kafka-sink-connector.adoc[Sink Docs] | 
 | *camel-facebook-kafka-connector* | true | true | xref:connectors/camel-facebook-kafka-sink-connector.adoc[Sink Docs] | xref:connectors/camel-facebook-kafka-source-connector.adoc[Source Docs]
 | *camel-fhir-kafka-connector* | true | true | xref:connectors/camel-fhir-kafka-sink-connector.adoc[Sink Docs] | xref:connectors/camel-fhir-kafka-source-connector.adoc[Source Docs]
@@ -262,7 +261,6 @@ Number of Camel Kafka connectors: 353
 | *camel-openstack-swift-kafka-connector* | true | false | xref:connectors/camel-openstack-swift-kafka-sink-connector.adoc[Sink Docs] | 
 | *camel-optaplanner-kafka-connector* | true | true | xref:connectors/camel-optaplanner-kafka-sink-connector.adoc[Sink Docs] | xref:connectors/camel-optaplanner-kafka-source-connector.adoc[Source Docs]
 | *camel-paho-kafka-connector* | true | true | xref:connectors/camel-paho-kafka-sink-connector.adoc[Sink Docs] | xref:connectors/camel-paho-kafka-source-connector.adoc[Source Docs]
-| *camel-paxlogging-kafka-connector* | false | true |  | xref:connectors/camel-paxlogging-kafka-source-connector.adoc[Source Docs]
 | *camel-pdf-kafka-connector* | true | false | xref:connectors/camel-pdf-kafka-sink-connector.adoc[Sink Docs] | 
 | *camel-pg-replication-slot-kafka-connector* | false | true |  | xref:connectors/camel-pg-replication-slot-kafka-source-connector.adoc[Source Docs]
 | *camel-pgevent-kafka-connector* | true | true | xref:connectors/camel-pgevent-kafka-sink-connector.adoc[Sink Docs] | xref:connectors/camel-pgevent-kafka-source-connector.adoc[Source Docs]
@@ -309,7 +307,6 @@ Number of Camel Kafka connectors: 353
 | *camel-solrs-kafka-connector* | true | false | xref:connectors/camel-solrs-kafka-sink-connector.adoc[Sink Docs] | 
 | *camel-soroush-kafka-connector* | true | true | xref:connectors/camel-soroush-kafka-sink-connector.adoc[Sink Docs] | xref:connectors/camel-soroush-kafka-source-connector.adoc[Source Docs]
 | *camel-spark-kafka-connector* | true | false | xref:connectors/camel-spark-kafka-sink-connector.adoc[Sink Docs] | 
-| *camel-spark-rest-kafka-connector* | false | true |  | xref:connectors/camel-spark-rest-kafka-source-connector.adoc[Source Docs]
 | *camel-splunk-hec-kafka-connector* | true | false | xref:connectors/camel-splunk-hec-kafka-sink-connector.adoc[Sink Docs] | 
 | *camel-splunk-kafka-connector* | true | true | xref:connectors/camel-splunk-kafka-sink-connector.adoc[Sink Docs] | xref:connectors/camel-splunk-kafka-source-connector.adoc[Source Docs]
 | *camel-spring-batch-kafka-connector* | true | false | xref:connectors/camel-spring-batch-kafka-sink-connector.adoc[Sink Docs] | 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -27,17 +27,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <activemq.version>5.15.12</activemq.version>
         <kafka.version>2.4.1</kafka.version>
-        <junit.version>5.6.2</junit.version>
         <camel.version>3.3.0</camel.version>
-        <jackson.version>2.10.4</jackson.version>
-        <slf4j.version>1.7.30</slf4j.version>
-        <log4j2.version>2.13.3</log4j2.version>
-        <version.commons-io>2.6</version.commons-io>
         <version.java>1.8</version.java>
         <version.guava>20.0</version.guava>
-
 
         <version.maven.compiler>3.8.1</version.maven.compiler>
         <version.maven.javadoc>3.1.1</version.maven.javadoc>
@@ -51,8 +44,6 @@
         <version.maven.failsafe>2.22.2</version.maven.failsafe>
         <version.maven.surefire>3.0.0-M4</version.maven.surefire>
         <version.scala.library>2.12.4</version.scala.library>
-        <version.testcontainers>1.14.2</version.testcontainers>
-        <version.qpid-jms-client>0.51.0</version.qpid-jms-client>
         <version.maven.maven-remote-resources-plugin>1.6.0</version.maven.maven-remote-resources-plugin>
 
         <version.maven.checkstyle>8.26</version.maven.checkstyle>
@@ -177,61 +168,61 @@
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
-                <version>${junit.version}</version>
+                <version>${junit-jupiter-version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
-                <version>${junit.version}</version>
+                <version>${junit-jupiter-version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-params</artifactId>
-                <version>${junit.version}</version>
+                <version>${junit-jupiter-version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-ext</artifactId>
-                <version>${slf4j.version}</version>
+                <version>${slf4j-version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
-                <version>${log4j2.version}</version>
+                <version>${log4j2-version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-1.2-api</artifactId>
-                <version>${log4j2.version}</version>
+                <version>${log4j2-version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
-                <version>${log4j2.version}</version>
+                <version>${log4j2-version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j-impl</artifactId>
-                <version>${log4j2.version}</version>
+                <version>${log4j2-version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-jcl</artifactId>
-                <version>${log4j2.version}</version>
+                <version>${log4j2-version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-jul</artifactId>
-                <version>${log4j2.version}</version>
+                <version>${log4j2-version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -243,48 +234,48 @@
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers</artifactId>
-                <version>${version.testcontainers}</version>
+                <version>${testcontainers-version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>junit-jupiter</artifactId>
-                <version>${version.testcontainers}</version>
+                <version>${testcontainers-version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>kafka</artifactId>
-                <version>${version.testcontainers}</version>
+                <version>${testcontainers-version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>localstack</artifactId>
-                <version>${version.testcontainers}</version>
+                <version>${testcontainers-version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>elasticsearch</artifactId>
-                <version>${version.testcontainers}</version>
+                <version>${testcontainers-version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.qpid</groupId>
                 <artifactId>qpid-jms-client</artifactId>
-                <version>${version.qpid-jms-client}</version>
+                <version>${qpid-jms-client-version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>${version.commons-io}</version>
+                <version>${commons-io-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-client</artifactId>
-                <version>${activemq.version}</version>
+                <version>${activemq-version}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.apache</groupId>
-        <artifactId>apache</artifactId>
-        <version>21</version>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-dependencies</artifactId>
+        <version>3.3.0</version>
     </parent>
 
     <groupId>org.apache.camel.kafkaconnector</groupId>


### PR DESCRIPTION
…kson, qpid, log4j etc and fixed camel-syslog-connector assembly

Fixes #241 