### PR TITLE
Adds integration tests for Salesforce

### DIFF
--- a/docs/modules/ROOT/pages/contributing.adoc
+++ b/docs/modules/ROOT/pages/contributing.adoc
@@ -97,4 +97,68 @@ mvn -Dkafka.bootstrap.servers=host1:port -Dkafka.instance.type=remote -DskipInte
 
 It's possible to use a properties file to set these properties. To do so use `-Dtest.properties=/path/to/file.properties`.
 
+==== Running Salesforce integration tests
 
+The first step is to create an account on Salesforce. The service allows developers to create a free account for testing.
+The account can be created on their https://login.salesforce.com/[login] website.
+
+The next step is to create a new connected application. This will provide you with the API keys that allow the
+automation to run. The https://help.salesforce.com/articleView?id=connected_app_create_api_integration.htm[Salesforce help]
+contains the documentation and steps related to this part of the process.
+
+After you create the API keys proceed to adjust a few more parameters necessary for the tests to run. Specifically, the
+https://help.salesforce.com/articleView?err=1&id=connected_app_overview.htm&type=5[IP Relaxation/range policy] parameter
+should be adjusted (usually to the value "Relax IP restrictions").
+
+You need setup change data capture to allow our tests to read from the Account table. The
+https://developer.salesforce.com/docs/atlas.en-us.change_data_capture.meta/change_data_capture/cdc_intro.htm[Change Data Capture Developer Guide]
+on the Salesforce documentation is the recommended starting point for this.
+
+Lastly, you need to create the configuration files for the `sfdx` CLI client. The CLI client interacts with the account,
+creating, updating and deleting records as required for the test execution.
+
+To generate the configuration files, execute the following steps:
+
+1. Run the Salesforce CLI container:
+`docker run --rm --name salesforce-cli -it -v /path/to/sfdx:/root/.sfdx salesforce/salesforcedx`
+
+2. Within the container, use the following command to login:
+`sfdx force:auth:device:login -s -d -i <client ID>`
+
+3. Provide the client secret when request and execute the steps requested by the CLI.
+
+4. Verify that you are logged in correctly using the following command
+`sfdx force:auth:list`
+
+It should present an output like:
+
+----
+#### authenticated orgs
+ALIAS  USERNAME              ORG ID              INSTANCE URL                 OAUTH METHOD
+─────  ────────────────────  ──────────────────  ───────────────────────────  ────────────
+       your-user@email.com  SOME NUMERIC ID     https://eu31.salesforce.com  web
+----
+
+*Note*: after leaving the container you might need to adjust the permissions of the directory containing the `sfdx`
+configuration files (`/path/to/sfdx`).
+
+Using the IDs, credentials and configurations that you created, you need to set the following system properties to run
+the tests using maven:
+
+* `-Dit.test.salesforce.enable=true` to enable the test
+* `-Dit.test.salesforce.client.id=<client ID>` with the client ID obtained when you created the API keys
+* `-Dit.test.salesforce.client.secret=<client secret>` with the client secret obtained when you created the API keys
+* `-Dit.test.salesforce.password=<user password>` the password of your account
+* `-Dit.test.salesforce.username=<user name>` the username of your account.
+* `-Dit.test.salesforce.sfdx.path=/path/to/sfdx` the path to the sfdx configuration (explained further).
+
+*Note*: the `it.test.salesforce.sfdx.path` property should point to the directory containing the sfdx CLI client
+configuration.
+
+To run the tests, enable the `salesforce` profile so that DTOs are generated and set the aforementioned properties to
+the values setup previously.
+
+[source,bash]
+----
+mvn -U -Psalesforce -DskipIntegrationTests=false -Dit.test.salesforce.sfdx.path=/path/to/sfdx -Dit.test.salesforce.enable=true -Dit.test.salesforce.client.id=<client id> -Dit.test.salesforce.client.secret=<client secret> -Dit.test.salesforce.password=<password> -Dit.test.salesforce.username=<your account> compile test-compile test
+----

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -31,6 +31,7 @@
         <camel.version>3.3.0</camel.version>
         <version.java>1.8</version.java>
         <version.guava>20.0</version.guava>
+        <version.javax.annotation-api>1.3.2</version.javax.annotation-api>
 
         <version.maven.compiler>3.8.1</version.maven.compiler>
         <version.maven.javadoc>3.1.1</version.maven.javadoc>
@@ -277,6 +278,13 @@
                 <artifactId>activemq-client</artifactId>
                 <version>${activemq-version}</version>
                 <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>${version.javax.annotation-api}</version>
+                <scope>compile</scope>
             </dependency>
 
         </dependencies>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -263,6 +263,7 @@
                     <failIfNoTests>false</failIfNoTests>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
@@ -286,5 +287,79 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>salesforce</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+
+            <dependencies>
+                <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>camel-salesforce</artifactId>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.camel.maven</groupId>
+                        <artifactId>camel-salesforce-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>generate</id>
+                                <goals>
+                                    <goal>generate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <clientId>${it.test.salesforce.client.id}</clientId>
+                            <clientSecret>${it.test.salesforce.client.secret}</clientSecret>
+                            <userName>${it.test.salesforce.username}</userName>
+                            <password>${it.test.salesforce.password}</password>
+                            <loginUrl default-value="https://login.salesforce.com">${it.test.salesforce.login.url}</loginUrl>
+                            <includes>
+                                <include>Account</include>
+                                <include>Contacts</include>
+                            </includes>
+                            <httpProxyHost>${it.test.salesforce.httpProxyHost}</httpProxyHost>
+                            <httpProxyPort>${it.test.salesforce.httpProxyPort}</httpProxyPort>
+                        </configuration>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>add-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>${project.build.directory}/generated-sources/camel-salesforce</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+
+        </profile>
+    </profiles>
 
 </project>

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/PluginPathHelper.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/PluginPathHelper.java
@@ -37,7 +37,8 @@ public final class PluginPathHelper {
         "connectors/camel-aws-s3-kafka-connector", "connectors/camel-aws-kinesis-kafka-connector",
         "connectors/camel-elasticsearch-rest-kafka-connector", "connectors/camel-http-kafka-connector",
         "connectors/camel-timer-kafka-connector", "connectors/camel-file-kafka-connector",
-        "connectors/camel-slack-kafka-connector", "connectors/camel-syslog-kafka-connector"
+        "connectors/camel-salesforce-kafka-connector", "connectors/camel-slack-kafka-connector",
+        "connectors/camel-syslog-kafka-connector",
     };
 
     private static class PluginWalker extends DirectoryWalker<String> {

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/TestCommon.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/TestCommon.java
@@ -131,4 +131,10 @@ public final class TestCommon {
 
         } while (!state && retries > 0);
     }
+
+    public static int randomWithRange(int min, int max) {
+        int range = (max - min) + 1;
+
+        return (int)(Math.random() * range) + min;
+    }
 }

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/clients/salesforce/SalesforceCliContainer.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/clients/salesforce/SalesforceCliContainer.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kafkaconnector.clients.salesforce;
+
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+public class SalesforceCliContainer extends GenericContainer<SalesforceCliContainer> {
+    private static final Logger LOG = LoggerFactory.getLogger(SalesforceCliContainer.class);
+    private static final String HOST_PATH = System.getProperty("it.test.salesforce.sfdx.path");
+
+
+    public SalesforceCliContainer() {
+        super("salesforce/salesforcedx");
+
+        withFileSystemBind(HOST_PATH, "/root/.sfdx");
+
+        withCommand("/bin/bash", "-c", "echo running ; while true ; do sleep 1 ; echo running ; done");
+        waitingFor(Wait.forLogMessage(".*running.*", 1));
+    }
+
+    public ExecResult execCommand(SfdxCommand sfdxCommand) throws IOException, InterruptedException {
+        return execInContainer(sfdxCommand.commands());
+    }
+
+    public static boolean verifyCommand(SfdxCommand sfdxCommand, ExecResult result) {
+        if (result.getExitCode() != 0) {
+            LOG.error("Unable to execute command (stdout): {}", sfdxCommand.commands());
+            LOG.error("Command stdout: {}", result.getStdout());
+            LOG.error("Command stderr: {}", result.getStderr());
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/clients/salesforce/SfdxCommand.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/clients/salesforce/SfdxCommand.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kafkaconnector.clients.salesforce;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class SfdxCommand {
+    private List<String> commands = new ArrayList<>();
+
+    private SfdxCommand() {
+        commands.add("sfdx");
+    }
+
+    public SfdxCommand withArgument(String argument) {
+        commands.add(argument);
+
+        return this;
+    }
+
+    public SfdxCommand withArgument(String argument, String value) {
+        commands.add(argument);
+        commands.add(value);
+
+        return this;
+    }
+
+    public static SfdxCommand forceDataRecordCreate() {
+        SfdxCommand command = new SfdxCommand();
+
+        return command.withArgument("force:data:record:create");
+    }
+
+    public static SfdxCommand forceDataRecordDelete() {
+        SfdxCommand command = new SfdxCommand();
+
+        return command.withArgument("force:data:record:delete");
+    }
+
+    public static SfdxCommand forceDataRecordUpdate() {
+        SfdxCommand command = new SfdxCommand();
+
+        return command.withArgument("force:data:record:update");
+    }
+
+    public String[] commands() {
+        return commands.toArray(new String[0]);
+    }
+}

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/clients/salesforce/SfdxCommand.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/clients/salesforce/SfdxCommand.java
@@ -58,6 +58,12 @@ public final class SfdxCommand {
         return command.withArgument("force:data:record:update");
     }
 
+    public static SfdxCommand forceDataRecordGet() {
+        SfdxCommand command = new SfdxCommand();
+
+        return command.withArgument("force:data:record:get");
+    }
+
     public String[] commands() {
         return commands.toArray(new String[0]);
     }

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/salesforce/CamelSalesforcePropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/salesforce/CamelSalesforcePropertyFactory.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kafkaconnector.sink.salesforce;
+
+import org.apache.camel.kafkaconnector.SourceConnectorPropertyFactory;
+
+public class CamelSalesforcePropertyFactory extends SourceConnectorPropertyFactory<CamelSalesforcePropertyFactory> {
+
+    public CamelSalesforcePropertyFactory withClientId(String value) {
+        return setProperty("camel.component.salesforce.clientId", value);
+    }
+
+    public CamelSalesforcePropertyFactory withClientSecret(String value) {
+        return setProperty("camel.component.salesforce.clientSecret", value);
+    }
+
+    public CamelSalesforcePropertyFactory withPassword(String value) {
+        return setProperty("camel.component.salesforce.password", value);
+    }
+
+    public CamelSalesforcePropertyFactory withUserName(String value) {
+        return setProperty("camel.component.salesforce.userName", value);
+    }
+
+    public CamelSalesforcePropertyFactory withLoginUrl(String value) {
+        return setProperty("camel.component.salesforce.loginUrl", value);
+    }
+
+    public CamelSalesforcePropertyFactory withRawPayload(boolean value) {
+        return setProperty("camel.component.salesforce.rawPayload", value);
+    }
+
+    public CamelSalesforcePropertyFactory withPackages(String value) {
+        return setProperty("camel.component.salesforce.packages", value);
+    }
+
+    public CamelSalesforcePropertyFactory withApiVersion(String value) {
+        return setProperty("camel.component.salesforce.apiVersion", value);
+    }
+
+    public CamelSalesforcePropertyFactory withOperationName(String value) {
+        return setProperty("camel.sink.path.operationName", value);
+    }
+
+    public CamelSalesforcePropertyFactory withSObjectName(String value) {
+        return setProperty("camel.sink.endpoint.sObjectName", value);
+    }
+
+    public static CamelSalesforcePropertyFactory basic() {
+        return new CamelSalesforcePropertyFactory()
+                .withName("CamelSalesforceConnector")
+                .withLoginUrl("https://login.salesforce.com")
+                .withTasksMax(1)
+                .withConnectorClass("org.apache.camel.kafkaconnector.salesforce.CamelSalesforceSinkConnector")
+                .withKeyConverterClass("org.apache.kafka.connect.storage.StringConverter")
+                .withValueConverterClass("org.apache.kafka.connect.storage.StringConverter");
+    }
+
+
+}

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/sink/salesforce/CamelSinkSalesforceITCase.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/sink/salesforce/CamelSinkSalesforceITCase.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kafkaconnector.sink.salesforce;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.camel.kafkaconnector.AbstractKafkaTest;
+import org.apache.camel.kafkaconnector.ConnectorPropertyFactory;
+import org.apache.camel.kafkaconnector.TestCommon;
+import org.apache.camel.kafkaconnector.clients.kafka.KafkaClient;
+import org.apache.camel.kafkaconnector.clients.salesforce.SalesforceCliContainer;
+import org.apache.camel.kafkaconnector.clients.salesforce.SfdxCommand;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Container.ExecResult;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.apache.camel.kafkaconnector.clients.salesforce.SalesforceCliContainer.verifyCommand;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+
+/* This test is disabled by default because requires setup on Salesforce end.
+
+Creating API keys:
+https://help.salesforce.com/articleView?id=connected_app_create_api_integration.htm
+
+You need to set the following system properties to run this test:
+-Dit.test.salesforce.enable=true to enable the test
+-Dit.test.salesforce.client.id=<client ID>
+-Dit.test.salesforce.client.secret=<client secret>
+-Dit.test.salesforce.password=<user password>
+-Dit.test.salesforce.username=<user name>
+-Dit.test.salesforce.sfdx.path=/path/to/sfdx
+
+The it.test.salesforce.sfdx.path property should point to the directory containing the sfdx
+CLI client configuration. This can be generated using the following steps:
+
+1. Run the Salesforce CLI container:
+docker run --rm --name salesforce-cli -it -v /path/to/sfdx:/root/.sfdx salesforce/salesforcedx
+
+2. Within the container, use the following command to login:
+sfdx force:auth:device:login -s -d -i <client ID>
+
+3. Provide the client secret when request and execute the steps requested by the CLI.
+
+4. Verify that you are logged in correctly using the following command
+sfdx force:auth:list
+
+It should present an output like:
+
+#### authenticated orgs
+ALIAS  USERNAME              ORG ID              INSTANCE URL                 OAUTH METHOD
+─────  ────────────────────  ──────────────────  ───────────────────────────  ────────────
+       angusyoung@gmail.com  SOME NUMERIC ID     https://eu31.salesforce.com  web
+
+
+Note: after leaving the container you might need to adjust the permissions of the directory
+containing the sfdx configuration files (/path/to/sfdx).
+*/
+@Testcontainers
+@EnabledIfSystemProperty(named = "it.test.salesforce.enable", matches = "true")
+public class CamelSinkSalesforceITCase extends AbstractKafkaTest {
+    private static final Logger LOG = LoggerFactory.getLogger(CamelSinkSalesforceITCase.class);
+
+    @Container
+    public final SalesforceCliContainer container = new SalesforceCliContainer();
+
+    private final String clientId = System.getProperty("it.test.salesforce.client.id");
+    private final String clientSecret = System.getProperty("it.test.salesforce.client.secret");
+    private final String password = System.getProperty("it.test.salesforce.password");
+    private final String userName = System.getProperty("it.test.salesforce.username");
+
+    private String accountName;
+    private boolean recordCreated;
+
+    @BeforeEach
+    public void setUp() {
+        accountName = "TestSinkAccount" + TestCommon.randomWithRange(1, 100);
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException, InterruptedException {
+        SfdxCommand sfdxCommand = SfdxCommand.forceDataRecordDelete()
+                .withArgument("--sobjecttype", "Account")
+                .withArgument("--where", String.format("Name=%s", accountName));
+
+        LOG.debug("Deleting the test account {}", accountName);
+        ExecResult result = container.execCommand(sfdxCommand);
+        if (!verifyCommand(sfdxCommand, result)) {
+            fail("Unable to delete the test account on Salesforce");
+        }
+
+        accountName = null;
+    }
+
+
+    private boolean waitForRecordCreation() {
+        SfdxCommand sfdxCommand = SfdxCommand.forceDataRecordGet()
+                .withArgument("--sobjecttype", "Account")
+                .withArgument("--where", String.format("Name=%s", accountName));
+
+        LOG.debug("Check if the test account {} was created on Salesforce", accountName);
+        try {
+            ExecResult result = container.execCommand(sfdxCommand);
+
+            if (verifyCommand(sfdxCommand, result)) {
+                recordCreated = true;
+                return true;
+            }
+
+        } catch (IOException e) {
+            LOG.warn("I/O exception while checking if the record was created: {}", e.getMessage(), e);
+
+            return false;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+
+            LOG.warn("The thread was interrupted while waiting for the record creation");
+            return false;
+        }
+
+        return false;
+    }
+
+
+    private void runTest(ConnectorPropertyFactory connectorPropertyFactory) throws ExecutionException, InterruptedException {
+        connectorPropertyFactory.log();
+        getKafkaConnectService().initializeConnectorBlocking(connectorPropertyFactory, 1);
+
+        KafkaClient<String, String> kafkaClient = new KafkaClient<>(getKafkaService().getBootstrapServers());
+
+        // Ideally we should use the DTOs, but they cause the source check to fail
+        String data = String.format("{\"attributes\":{\"referenceId\":null,\"type\":\"Account\",\"url\":null},"
+                + "\"Description\":\"%s\",\"Name\":\"%s\"}", "Created during sink test", accountName);
+
+        LOG.info("Sending new account {}", data);
+
+        kafkaClient.produce(TestCommon.getDefaultTestTopic(this.getClass()), data);
+    }
+
+    @Test
+    @Timeout(180)
+    public void testBasicProduce() throws ExecutionException, InterruptedException {
+        ConnectorPropertyFactory factory = CamelSalesforcePropertyFactory.basic()
+                .withKafkaTopic(TestCommon.getDefaultTestTopic(this.getClass()))
+                .withUserName(userName)
+                .withPassword(password)
+                .withClientId(clientId)
+                .withClientSecret(clientSecret)
+                .withRawPayload(true)
+                .withPackages("org.apache.camel.salesforce.dto")
+                .withSObjectName("Account")
+                .withOperationName("createSObject");
+
+        runTest(factory);
+
+        TestCommon.waitFor(this::waitForRecordCreation);
+        assertTrue(recordCreated, "The record was not created");
+    }
+}

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/source/salesforce/CamelSalesforcePropertyFactory.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/source/salesforce/CamelSalesforcePropertyFactory.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kafkaconnector.source.salesforce;
+
+import org.apache.camel.kafkaconnector.EndpointUrlBuilder;
+import org.apache.camel.kafkaconnector.SourceConnectorPropertyFactory;
+
+final class CamelSalesforcePropertyFactory extends SourceConnectorPropertyFactory<CamelSalesforcePropertyFactory> {
+    private CamelSalesforcePropertyFactory() {
+
+    }
+
+    public CamelSalesforcePropertyFactory withClientId(String value) {
+        return setProperty("camel.component.salesforce.clientId", value);
+    }
+
+    public CamelSalesforcePropertyFactory withClientSecret(String value) {
+        return setProperty("camel.component.salesforce.clientSecret", value);
+    }
+
+    public CamelSalesforcePropertyFactory withPassword(String value) {
+        return setProperty("camel.component.salesforce.password", value);
+    }
+
+    public CamelSalesforcePropertyFactory withUserName(String value) {
+        return setProperty("camel.component.salesforce.userName", value);
+    }
+
+    public CamelSalesforcePropertyFactory withNotifyForFields(String fields) {
+        return setProperty("camel.source.endpoint.notifyForFields", fields);
+    }
+
+    public CamelSalesforcePropertyFactory withNotifyForOperations(String value) {
+        return setProperty("camel.source.endpoint.notifyForOperations", value);
+    }
+
+    public CamelSalesforcePropertyFactory withNotifyForOperationCreate(String value) {
+        return setProperty("camel.component.salesforce.notifyForOperationCreate", value);
+    }
+
+    public CamelSalesforcePropertyFactory withNotifyForOperationDelete(String value) {
+        return setProperty("camel.component.salesforce.notifyForOperationDelete", value);
+    }
+
+    public CamelSalesforcePropertyFactory withNotifyForOperationUpdate(String value) {
+        return setProperty("camel.component.salesforce.notifyForOperationUpdate", value);
+    }
+
+    public CamelSalesforcePropertyFactory withHttpClient(String value) {
+        return setProperty("camel.source.endpoint.httpClient", classRef(value));
+    }
+
+    public CamelSalesforcePropertyFactory withSObjectName(String value) {
+        return setProperty("camel.source.endpoint.sObjectName", value);
+    }
+
+    public CamelSalesforcePropertyFactory withSObjectQuery(String value) {
+        return setProperty("camel.source.endpoint.sObjectQuery", value);
+    }
+
+    public CamelSalesforcePropertyFactory withSObjectClass(String value) {
+        return setProperty("camel.component.salesforce.sObjectClass", value);
+    }
+
+    public CamelSalesforcePropertyFactory withUpdateTopic(boolean value) {
+        return setProperty("camel.source.endpoint.updateTopic", value);
+    }
+
+    public CamelSalesforcePropertyFactory withLoginUrl(String value) {
+        return setProperty("camel.component.salesforce.loginUrl", value);
+    }
+
+    public CamelSalesforcePropertyFactory withTopicName(String value) {
+        return setProperty("camel.source.path.topicName", value);
+    }
+
+    public CamelSalesforcePropertyFactory withRawPayload(boolean value) {
+        return setProperty("camel.source.endpoint.rawPayload", value);
+    }
+
+    public CamelSalesforcePropertyFactory withPackages(String value) {
+        return setProperty("camel.component.salesforce.packages", value);
+    }
+
+    public CamelSalesforcePropertyFactory withReplayId(int value) {
+        return setProperty("camel.source.endpoint.replayId", value);
+    }
+
+    public CamelSalesforcePropertyFactory withApiVersion(String value) {
+        return setProperty("camel.component.salesforce.apiVersion", value);
+    }
+
+    public EndpointUrlBuilder<CamelSalesforcePropertyFactory> withUrl(String topic) {
+        String queueUrl = String.format("salesforce:%s", topic);
+
+        return new EndpointUrlBuilder<>(this::withSourceUrl, queueUrl);
+    }
+
+    public static CamelSalesforcePropertyFactory basic() {
+        return new CamelSalesforcePropertyFactory()
+                .withName("CamelSalesforceConnector")
+                .withTasksMax(1)
+                .withConnectorClass("org.apache.camel.kafkaconnector.salesforce.CamelSalesforceSourceConnector")
+                .withKeyConverterClass("org.apache.kafka.connect.storage.StringConverter")
+                .withValueConverterClass("org.apache.kafka.connect.storage.StringConverter")
+                .withLoginUrl("https://login.salesforce.com");
+
+    }
+
+}

--- a/tests/src/test/java/org/apache/camel/kafkaconnector/source/salesforce/CamelSourceSalesforceITCase.java
+++ b/tests/src/test/java/org/apache/camel/kafkaconnector/source/salesforce/CamelSourceSalesforceITCase.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kafkaconnector.source.salesforce;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.kafkaconnector.AbstractKafkaTest;
+import org.apache.camel.kafkaconnector.ConnectorPropertyFactory;
+import org.apache.camel.kafkaconnector.TestCommon;
+import org.apache.camel.kafkaconnector.clients.kafka.KafkaClient;
+import org.apache.camel.kafkaconnector.clients.salesforce.SalesforceCliContainer;
+import org.apache.camel.kafkaconnector.clients.salesforce.SfdxCommand;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Container.ExecResult;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+
+import static org.apache.camel.kafkaconnector.clients.salesforce.SalesforceCliContainer.verifyCommand;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/* This test is disabled by default because requires setup on Salesforce end.
+
+Creating API keys:
+https://help.salesforce.com/articleView?id=connected_app_create_api_integration.htm
+
+You need to set the following system properties to run this test:
+-Dit.test.salesforce.enable=true to enable the test
+-Dit.test.salesforce.client.id=<client ID>
+-Dit.test.salesforce.client.secret=<client secret>
+-Dit.test.salesforce.password=<user password>
+-Dit.test.salesforce.username=<user name>
+-Dit.test.salesforce.sfdx.path=/path/to/sfdx
+
+The it.test.salesforce.sfdx.path property should point to the directory containing the sfdx
+CLI client configuration. This can be generated using the following steps:
+
+1. Run the Salesforce CLI container:
+docker run --rm --name salesforce-cli -it -v /path/to/sfdx:/root/.sfdx salesforce/salesforcedx
+
+2. Within the container, use the following command to login:
+sfdx force:auth:device:login -s -d -i <client ID>
+
+3. Provide the client secret when request and execute the steps requested by the CLI.
+
+4. Verify that you are logged in correctly using the following command
+sfdx force:auth:list
+
+It should present an output like:
+
+#### authenticated orgs
+ALIAS  USERNAME              ORG ID              INSTANCE URL                 OAUTH METHOD
+─────  ────────────────────  ──────────────────  ───────────────────────────  ────────────
+       angusyoung@gmail.com  SOME NUMERIC ID     https://eu31.salesforce.com  web
+
+
+Note: after leaving the container you might need to adjust the permissions of the directory
+containing the sfdx configuration files (/path/to/sfdx).
+*/
+@Testcontainers
+@EnabledIfSystemProperty(named = "it.test.salesforce.enable", matches = "true")
+public class CamelSourceSalesforceITCase extends AbstractKafkaTest  {
+    private static final Logger LOG = LoggerFactory.getLogger(CamelSourceSalesforceITCase.class);
+
+    @Container
+    public final SalesforceCliContainer container = new SalesforceCliContainer();
+
+    private final String clientId = System.getProperty("it.test.salesforce.client.id");
+    private final String clientSecret = System.getProperty("it.test.salesforce.client.secret");
+    private final String password = System.getProperty("it.test.salesforce.password");
+    private final String userName = System.getProperty("it.test.salesforce.username");
+
+    private volatile boolean received;
+    private String account;
+
+    @BeforeEach
+    public void setUp() throws IOException, InterruptedException {
+        received = false;
+
+        account = "TestAccount" + TestCommon.randomWithRange(1, 100);
+
+        SfdxCommand sfdxCommand = SfdxCommand.forceDataRecordCreate()
+                .withArgument("--sobjecttype", "Account")
+                .withArgument("--values", String.format("Name=%s", account));
+
+        LOG.debug("Creating the test account");
+        ExecResult result = container.execCommand(sfdxCommand);
+        if (!verifyCommand(sfdxCommand, result)) {
+            fail("Unable to create test account on Salesforce");
+        }
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException, InterruptedException {
+        SfdxCommand sfdxCommand = SfdxCommand.forceDataRecordDelete()
+                .withArgument("--sobjecttype", "Account")
+                .withArgument("--where", String.format("Name=%s", account));
+
+        LOG.debug("Deleting the test account");
+        ExecResult result = container.execCommand(sfdxCommand);
+        if (!verifyCommand(sfdxCommand, result)) {
+            fail("Unable to delete the test account on Salesforce");
+        }
+        account = null;
+    }
+
+    private <T> boolean checkRecord(ConsumerRecord<String, T> record) {
+        LOG.debug("Received: {}", record.value());
+        received  = true;
+
+        return false;
+    }
+
+    public void runBasicTest(ConnectorPropertyFactory connectorPropertyFactory) throws ExecutionException, InterruptedException {
+        connectorPropertyFactory.log();
+        getKafkaConnectService().initializeConnectorBlocking(connectorPropertyFactory, 1);
+
+        LOG.debug("Creating the consumer ...");
+        KafkaClient<String, String> kafkaClient = new KafkaClient<>(getKafkaService().getBootstrapServers());
+        kafkaClient.consume(TestCommon.getDefaultTestTopic(this.getClass()), this::checkRecord);
+        LOG.debug("Created the consumer ...");
+
+        assertTrue(received, "Didn't receive any messages");
+    }
+
+
+    private boolean updateTestAccount() {
+        final int limit = 50;
+        int count = 0;
+
+
+        while (!received && count < limit) {
+            LOG.debug("Updating the account to desc {}", count);
+
+            try {
+                SfdxCommand sfdxCommand = SfdxCommand.forceDataRecordUpdate()
+                        .withArgument("--sobjecttype", "Account")
+                        .withArgument("--where", String.format("Name=%s", account))
+                        .withArgument("--values", String.format("Description=desc%d", count));
+
+                LOG.debug("Updating the test account");
+                ExecResult result = container.execCommand(sfdxCommand);
+                if (!verifyCommand(sfdxCommand, result)) {
+                    fail("Unable to delete the test account on Salesforce");
+                }
+
+                Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+            } catch (IOException e) {
+                LOG.error("I/O exception while updating the account: {}", e.getMessage(), e);
+
+                return false;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                LOG.error("Interrupted while updating the account: {}", e.getMessage(), e);
+
+                return false;
+            }
+
+            count++;
+        }
+
+        if (count >= limit) {
+            return false;
+        }
+
+        return true;
+    }
+
+
+    @Test
+    @Timeout(180)
+    public void testBasicConsume() throws ExecutionException, InterruptedException {
+        ConnectorPropertyFactory factory = CamelSalesforcePropertyFactory.basic()
+                .withKafkaTopic(TestCommon.getDefaultTestTopic(this.getClass()))
+                .withUserName(userName)
+                .withPassword(password)
+                .withClientId(clientId)
+                .withClientSecret(clientSecret)
+                .withNotifyForFields("ALL")
+                .withUpdateTopic(true)
+                .withRawPayload(true)
+                .withPackages("org.apache.camel.salesforce.dto")
+                .withSObjectClass("org.apache.camel.salesforce.dto.Account")
+                .withSObjectQuery("SELECT Id, Name FROM Account")
+                .withTopicName("CamelKafkaConnectorTopic");
+
+        Executors.newCachedThreadPool().submit(this::updateTestAccount);
+
+        runBasicTest(factory);
+    }
+
+
+    @Test
+    @Timeout(180)
+    public void testBasicConsumeUsingUrl() throws ExecutionException, InterruptedException {
+        ConnectorPropertyFactory factory = CamelSalesforcePropertyFactory.basic()
+                .withKafkaTopic(TestCommon.getDefaultTestTopic(this.getClass()))
+                .withUserName(userName)
+                .withPassword(password)
+                .withClientId(clientId)
+                .withClientSecret(clientSecret)
+                .withUrl("CamelKafkaConnectorTopic")
+                    .append("notifyForFields", "ALL")
+                    .append("updateTopic", "true")
+                    .append("rawPayload", "true")
+                    .append("sObjectClass", "org.apache.camel.salesforce.dto.Account")
+                    .append("sObjectQuery", "SELECT Id, Name FROM Account")
+                    .buildUrl();
+
+        Executors.newCachedThreadPool().submit(this::updateTestAccount);
+
+        runBasicTest(factory);
+    }
+
+
+    /*
+     For this test to work, Change Data Capture need to be enabled on the setup. For lightnining, as of now, this is
+     Setup -> Integrations -> Change Data Capture
+     */
+    @Test
+    @Timeout(180)
+    public void testBasicCDC() throws ExecutionException, InterruptedException {
+        /*
+         * NOTE: this test requires SalesForce API >= than 37.0. Camel defaults to
+         * API version 34.0.
+         *
+         * The reason is that on older versions of this API did not return the list
+         * of supported extensions during the hand-shake (ie.:
+         * ext={replay=true, payload.format=true}). This behavior causes the rcvMeta
+         * handler on the CometDReplayExtension class in the salesforce component to
+         * consider the replay extension as "not supported".
+         *
+         * Subsequently, when using the /meta/subscribe channel to subscribe to
+         * account change events on /data/AccountChangeEvent, the replay ID is not
+         * provided on the request message - and it is a required parameter. This
+         * leads to a situation where the Salesforce API server returns a plain
+         * HTTP error 500 without much details.
+         */
+        ConnectorPropertyFactory factory = CamelSalesforcePropertyFactory.basic()
+                .withKafkaTopic(TestCommon.getDefaultTestTopic(this.getClass()))
+                .withUserName(userName)
+                .withPassword(password)
+                .withClientId(clientId)
+                .withClientSecret(clientSecret)
+                .withRawPayload(true)
+                .withReplayId(-2)
+                .withApiVersion("37.0")
+                .withTopicName("/data/AccountChangeEvent");
+
+        runBasicTest(factory);
+    }
+
+
+    @Test
+    @Timeout(180)
+    public void testBasicCDCUsingUrl() throws ExecutionException, InterruptedException {
+        ConnectorPropertyFactory factory = CamelSalesforcePropertyFactory.basic()
+                .withKafkaTopic(TestCommon.getDefaultTestTopic(this.getClass()))
+                .withUserName(userName)
+                .withPassword(password)
+                .withClientId(clientId)
+                .withClientSecret(clientSecret)
+                .withApiVersion("37.0")
+                .withUrl("data/AccountChangeEvent")
+                    .append("replayId", "-2")
+                    .append("rawPayload", "true")
+                    .buildUrl();
+
+        runBasicTest(factory);
+    }
+}

--- a/tests/src/test/resources/log4j2.properties
+++ b/tests/src/test/resources/log4j2.properties
@@ -60,3 +60,14 @@ logger.connector.name = org.apache.camel.kafkaconnector
 logger.connector.level = DEBUG
 logger.connector.additivity = false
 logger.connector.appenderRef.file.ref = file
+
+logger.camel-salesforce.name = org.apache.camel.component.salesforce
+logger.camel-salesforce.level = DEBUG
+logger.camel-salesforce.additivity = false
+logger.camel-salesforce.appenderRef.file.ref = file
+
+# This is useful for debugging Salesforce message exchanges.
+logger.cometd.name = org.cometd
+logger.cometd.level = DEBUG
+logger.cometd.additivity = false
+logger.cometd.appenderRef.file.ref = file


### PR DESCRIPTION
This adds some simple integration tests for Salesforce. Not all functionality
is covered, but I think it provides an initial infrastructure for future tests.

Currently covered:
- Source: basic data consumption tests + change data capture tests
- Sink: createSObject operation

The tests do not run by default. Because the Salesforce DTOs are required and
also some setup is required on Salesforce, the tests need to be enabled using
a maven profile (-Psalesforce) along with the required properties for the test
execution (all documented on the test classes).

Once this initial setup is done, the tests can run automatically.