### PR TITLE
Throw ConnectException due to failed exchanges

### DIFF
--- a/core/src/main/java/org/apache/camel/kafkaconnector/CamelSinkTask.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/CamelSinkTask.java
@@ -127,6 +127,10 @@ public class CamelSinkTask extends SinkTask {
 
             LOG.debug("Sending exchange {} to {}", exchange.getExchangeId(), LOCAL_URL);
             producer.send(LOCAL_URL, exchange);
+
+            if (exchange.isFailed()) {
+                throw new ConnectException("Exchange delivery has failed!", exchange.getException());
+            }
         }
     }
 


### PR DESCRIPTION
In case we have failed Camel exchanges, we throw  `ConnectException` in order to avoid the committing the offsets on failed messages and hence result of loss messages downstream. With this small modification, the task will directly shutdown upon failed exchanges and hence avoid any offsets being committed  