### PR TITLE
fix #259: Camel-elasticsearch-rest-kafka-connector throws java.lang.N…

### DIFF
--- a/connectors/camel-elasticsearch-rest-kafka-connector/pom.xml
+++ b/connectors/camel-elasticsearch-rest-kafka-connector/pom.xml
@@ -49,6 +49,10 @@
       <groupId>org.apache.camel.kafkaconnector</groupId>
       <artifactId>camel-kafka-connector</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+    </dependency>
     <!--END OF GENERATED CODE-->
   </dependencies>
   <build>

--- a/connectors/camel-kafka-connector-fix-dependencies.properties
+++ b/connectors/camel-kafka-connector-fix-dependencies.properties
@@ -28,3 +28,6 @@ additional_properties_camel-sjms2=camel.component.sjms2.connection-factory=#clas
 
 #XXX: temporary workaround waiting for https://issues.apache.org/jira/browse/CAMEL-15063 in camel 3.4.0
 additional_properties_camel-salesforce=camel.beans.salesforce=#class:org.apache.camel.component.salesforce.SalesforceComponentCKC
+
+# issue 259: https://github.com/apache/camel-kafka-connector/issues/259
+camel-elasticsearch-rest=org.slf4j:log4j-over-slf4j


### PR DESCRIPTION
…oClassDefFoundError: org/apache/logging/log4j/LogManager