### PR TITLE
Avoid logging the autoconfiguration summary from CamelMain

### DIFF
--- a/core/src/main/java/org/apache/camel/kafkaconnector/utils/CamelMainSupport.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/utils/CamelMainSupport.java
@@ -73,6 +73,7 @@ public class CamelMainSupport {
         };
 
         camelMain.addMainListener(new CamelMainFinishedListener());
+        camelMain.configure().setAutoConfigurationLogSummary(false);
 
         // reordering properties to place the one starting with "#class:" first
         LinkedHashMap<String, String> orderedProps = new LinkedHashMap<>();


### PR DESCRIPTION
Relates to #159 

We log the options two times. 