### PR TITLE
Re-enable a Cassandra test disabled due to CAMEL-15219

### DIFF
--- a/tests/itests-cassandra/src/test/java/org/apache/camel/kafkaconnector/cassandra/source/CamelSourceCassandraITCase.java
+++ b/tests/itests-cassandra/src/test/java/org/apache/camel/kafkaconnector/cassandra/source/CamelSourceCassandraITCase.java
@@ -31,7 +31,6 @@ import org.apache.camel.kafkaconnector.common.clients.kafka.KafkaClient;
 import org.apache.camel.kafkaconnector.common.utils.TestUtils;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -111,7 +110,6 @@ public class CamelSourceCassandraITCase extends AbstractKafkaTest {
         runTest(connectorPropertyFactory);
     }
 
-    @Disabled("Disabled due to CAMEL-15219")
     @Timeout(90)
     @Test
     public void testRetrieveFromCassandraWithCustomStrategy() throws ExecutionException, InterruptedException {


### PR DESCRIPTION
This test was disabled due to https://issues.apache.org/jira/browse/CAMEL-15219 which was fixed in Camel 3.4.2. 