### PR TITLE
AWS Kinesis test fixes when in remote mode

### DIFF
--- a/tests/itests-aws/src/test/java/org/apache/camel/kafkaconnector/aws/common/AWSCommon.java
+++ b/tests/itests-aws/src/test/java/org/apache/camel/kafkaconnector/aws/common/AWSCommon.java
@@ -38,19 +38,9 @@ public final class AWSCommon {
     public static final String DEFAULT_SQS_QUEUE_FOR_SNS = "ckcsns";
 
     /**
-     * The default SNS queue name used during the tests
-     */
-    public static final String DEFAULT_SNS_QUEUE = "ckc-sns";
-
-    /**
      * The default S3 bucket name used during the tests
      */
     public static final String DEFAULT_S3_BUCKET = "ckc-s3";
-
-    /**
-     * The default Kinesis stream name used during the tests
-     */
-    public static final String DEFAULT_KINESIS_STREAM = "ckc-kin-stream";
 
     private AWSCommon() {
 


### PR DESCRIPTION
Includes:

- Check for the stream presence before creating it
- Adjusted the code to use a different stream every test
- Removed unused test constants
- Removes unecessary sleep after deletion