### PR TITLE
Building endpoint uris should for secret options automatic use RAW() …

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -136,6 +136,11 @@
             <artifactId>camel-cassandraql</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-aws2-sqs</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/java/org/apache/camel/kafkaconnector/utils/TaskHelper.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/utils/TaskHelper.java
@@ -26,6 +26,9 @@ import org.apache.camel.LoggingLevel;
 import org.apache.camel.catalog.RuntimeCamelCatalog;
 import org.apache.camel.kafkaconnector.CamelSinkConnectorConfig;
 import org.apache.camel.kafkaconnector.CamelSourceConnectorConfig;
+import org.apache.camel.tooling.model.BaseOptionModel;
+import org.apache.camel.tooling.model.ComponentModel;
+import org.apache.camel.tooling.model.JsonMapper;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -37,10 +40,32 @@ public final class TaskHelper {
     }
 
     public static String buildUrl(RuntimeCamelCatalog rcc, Map<String, String> props, String componentSchema, String endpointPropertiesPrefix, String pathPropertiesPrefix) throws URISyntaxException {
+        ComponentModel cm = null;
+        if (componentSchema != null) {
+            String json = rcc.componentJSonSchema(componentSchema);
+            if (json != null) {
+                cm = JsonMapper.generateComponentModel(json);
+            }
+        }
+
         Map<String, String> filteredProps = new HashMap<>();
         props.keySet().stream()
                 .filter(k -> k.startsWith(endpointPropertiesPrefix) || k.startsWith(pathPropertiesPrefix))
                 .forEach(k -> filteredProps.put(k.replace(endpointPropertiesPrefix, "").replace(pathPropertiesPrefix, ""), props.get(k)));
+
+        if (cm != null) {
+            // secret options should have their values in RAW mode so we can preseve credentials/passwords etc in uri encodings
+            for (String k : filteredProps.keySet()) {
+                if (isSecretOption(rcc, cm, k)) {
+                    String value = filteredProps.get(k);
+                    if (value != null && !value.startsWith("RAW(")) {
+                        value = "RAW(" + value + ")";
+                        filteredProps.put(k, value);
+                    }
+                }
+            }
+        }
+
         return rcc.asEndpointUri(componentSchema, filteredProps, false);
     }
 
@@ -133,6 +158,13 @@ public final class TaskHelper {
                     break;
             }
         }
+    }
+
+    private static boolean isSecretOption(RuntimeCamelCatalog rcc, ComponentModel cm, String endpointName) {
+        return cm.getEndpointOptions().stream()
+                .filter(o -> o.getName().equals(endpointName))
+                .findFirst()
+                .map(BaseOptionModel::isSecret).orElse(false);
     }
 
 }

--- a/core/src/test/java/org/apache/camel/kafkaconnector/CamelSinkTaskTest.java
+++ b/core/src/test/java/org/apache/camel/kafkaconnector/CamelSinkTaskTest.java
@@ -632,4 +632,18 @@ public class CamelSinkTaskTest {
         sinkTask.stop();
     }
 
+    @Test
+    public void testSecretRaw() {
+        Map<String, String> props = new HashMap<>();
+        props.put(CamelSinkConnectorConfig.TOPIC_CONF, TOPIC_NAME);
+        props.put("camel.sink.endpoint.secretKey", "se+ret");
+        props.put("camel.sink.endpoint.accessKey", "MoreSe+ret$");
+        props.put(CamelSinkConnectorConfig.CAMEL_SINK_COMPONENT_CONF, "aws2-sqs");
+
+        CamelSinkTask sinkTask = new CamelSinkTask();
+        sinkTask.start(props);
+
+        sinkTask.stop();
+    }
+
 }


### PR DESCRIPTION
…syntax for the value so we wont have encoding issue for passwords or access tokens etc.

Here is a a bit rushed PR for a potential solution. When debugging I can see the endpoint is created with RAW() for those secret options. 
