### PR TITLE
Fix cassandra for camel 3.5

### DIFF
--- a/tests/itests-cassandra/src/test/java/org/apache/camel/kafkaconnector/cassandra/clients/CassandraClient.java
+++ b/tests/itests-cassandra/src/test/java/org/apache/camel/kafkaconnector/cassandra/clients/CassandraClient.java
@@ -17,24 +17,24 @@
 
 package org.apache.camel.kafkaconnector.cassandra.clients;
 
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.Session;
+import java.net.InetSocketAddress;
+
+import com.datastax.oss.driver.api.core.CqlSession;
 import org.apache.camel.kafkaconnector.cassandra.clients.dao.TestDataDao;
 
 /**
  * A simple client for Cassandra for testing purposes
  */
 public class CassandraClient {
-    private Cluster cluster;
-    private Session session;
+    private CqlSession session;
 
     public CassandraClient(String host, int port) {
-        cluster = Cluster.builder()
-                .addContactPoint(host)
-                .withPort(port)
-                .build();
+        InetSocketAddress socketAddress = new InetSocketAddress(host, port);
 
-        session = cluster.connect();
+        session = CqlSession.builder()
+                .addContactPoint(socketAddress)
+                .withLocalDatacenter("datacenter1")
+                .build();
     }
 
 

--- a/tests/itests-cassandra/src/test/java/org/apache/camel/kafkaconnector/cassandra/clients/dao/TestResultSetConversionStrategy.java
+++ b/tests/itests-cassandra/src/test/java/org/apache/camel/kafkaconnector/cassandra/clients/dao/TestResultSetConversionStrategy.java
@@ -21,8 +21,8 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import com.datastax.driver.core.ResultSet;
-import com.datastax.driver.core.Row;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.Row;
 import org.apache.camel.component.cassandra.ResultSetConversionStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/tests/itests-cassandra/src/test/java/org/apache/camel/kafkaconnector/cassandra/sink/CamelSinkCassandraITCase.java
+++ b/tests/itests-cassandra/src/test/java/org/apache/camel/kafkaconnector/cassandra/sink/CamelSinkCassandraITCase.java
@@ -77,7 +77,11 @@ public class CamelSinkCassandraITCase extends AbstractKafkaTest {
         cassandraClient = cassandraService.getClient();
 
         if (testDataDao != null) {
-            testDataDao.dropTable();
+            try {
+                testDataDao.dropTable();
+            } catch (Exception e) {
+                LOG.warn("Unable to drop the table: {}", e.getMessage(), e);
+            }
         }
     }
 

--- a/tests/itests-cassandra/src/test/java/org/apache/camel/kafkaconnector/cassandra/source/CamelSourceCassandraITCase.java
+++ b/tests/itests-cassandra/src/test/java/org/apache/camel/kafkaconnector/cassandra/source/CamelSourceCassandraITCase.java
@@ -19,7 +19,7 @@ package org.apache.camel.kafkaconnector.cassandra.source;
 
 import java.util.concurrent.ExecutionException;
 
-import com.datastax.driver.core.Row;
+import com.datastax.oss.driver.api.core.cql.Row;
 import org.apache.camel.kafkaconnector.cassandra.clients.CassandraClient;
 import org.apache.camel.kafkaconnector.cassandra.clients.dao.TestDataDao;
 import org.apache.camel.kafkaconnector.cassandra.clients.dao.TestResultSetConversionStrategy;
@@ -78,7 +78,11 @@ public class CamelSourceCassandraITCase extends AbstractKafkaTest {
         cassandraClient = cassandraService.getClient();
 
         if (testDataDao != null) {
-            testDataDao.dropTable();
+            try {
+                testDataDao.dropTable();
+            } catch (Exception e) {
+                LOG.warn("Unable to drop the table: {}", e.getMessage(), e);
+            }
         }
     }
 


### PR DESCRIPTION
Adjusts the client code to use the newer Cassandra client version from
camel-cassandraql