### PR TITLE
Fix mongodb test

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -65,8 +65,7 @@ for remote testing:
 ** hdfs.host
 ** hdfs.port
 * mongodb.instance.type
-** mongodb.host
-** mongodb.port
+** mongodb.url
 
 Additionally, a few manual tests can be enabled and executed with adequate configuration on the accounts and
 environments used by those services. This is very specific to the nature of each of those services, therefore

--- a/tests/itests-mongodb/src/test/java/org/apache/camel/kafkaconnector/mongodb/services/MongoDBLocalContainerService.java
+++ b/tests/itests-mongodb/src/test/java/org/apache/camel/kafkaconnector/mongodb/services/MongoDBLocalContainerService.java
@@ -41,18 +41,8 @@ public class MongoDBLocalContainerService implements MongoDBService {
     }
 
     @Override
-    public String getReplicaSetUrl() {
-        return container.getReplicaSetUrl();
-    }
-
-    @Override
-    public String getHost() {
-        return container.getContainerIpAddress();
-    }
-
-    @Override
-    public int getPort() {
-        return container.getMappedPort(DEFAULT_MONGODB_PORT);
+    public String getReplicaSetUrl() {    
+        return "mongodb://" + container.getContainerIpAddress() + ":" + container.getMappedPort(DEFAULT_MONGODB_PORT);
     }
 
     @Override

--- a/tests/itests-mongodb/src/test/java/org/apache/camel/kafkaconnector/mongodb/services/MongoDBService.java
+++ b/tests/itests-mongodb/src/test/java/org/apache/camel/kafkaconnector/mongodb/services/MongoDBService.java
@@ -35,10 +35,6 @@ public interface MongoDBService extends BeforeAllCallback, AfterAllCallback {
 
     String getReplicaSetUrl();
 
-    String getHost();
-
-    int getPort();
-
     MongoClient getClient();
 
     @Override

--- a/tests/itests-mongodb/src/test/java/org/apache/camel/kafkaconnector/mongodb/services/RemoteMongoDBService.java
+++ b/tests/itests-mongodb/src/test/java/org/apache/camel/kafkaconnector/mongodb/services/RemoteMongoDBService.java
@@ -21,25 +21,9 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 
 public class RemoteMongoDBService implements MongoDBService {
-    private static final int MONGODB_PORT = 27017;
 
-    public int getPort() {
-        String strPort = System.getProperty("mongodb.port");
-
-        if (strPort != null) {
-            return Integer.parseInt(strPort);
-        }
-
-        return MONGODB_PORT;
-    }
-
-    public String getHost() {
-        return System.getProperty("mongodb.host");
-    }
-
-    @Override
     public String getReplicaSetUrl() {
-        return getHost() + ":" + getPort();
+        return System.getProperty("mongodb.url");
     }
 
     @Override

--- a/tests/itests-mongodb/src/test/java/org/apache/camel/kafkaconnector/mongodb/sink/CamelSinkMongoDBITCase.java
+++ b/tests/itests-mongodb/src/test/java/org/apache/camel/kafkaconnector/mongodb/sink/CamelSinkMongoDBITCase.java
@@ -105,9 +105,8 @@ public class CamelSinkMongoDBITCase extends AbstractKafkaTest {
     @Test
     @Timeout(90)
     public void testBasicSendReceive() throws ExecutionException, InterruptedException {
-        String connectionBeanRef = String.format("com.mongodb.client.MongoClients#create('mongodb://%s:%d')",
-                mongoDBService.getHost(),
-                mongoDBService.getPort());
+        String connectionBeanRef = String.format("com.mongodb.client.MongoClients#create('%s')",
+                mongoDBService.getReplicaSetUrl());
 
         CamelMongoDBPropertyFactory factory = CamelMongoDBPropertyFactory.basic()
                 .withTopics(TestUtils.getDefaultTestTopic(this.getClass()))

--- a/tests/itests-mongodb/src/test/java/org/apache/camel/kafkaconnector/mongodb/source/CamelSourceMongoDBITCase.java
+++ b/tests/itests-mongodb/src/test/java/org/apache/camel/kafkaconnector/mongodb/source/CamelSourceMongoDBITCase.java
@@ -118,9 +118,8 @@ public class CamelSourceMongoDBITCase extends AbstractKafkaTest {
     @Test
     @Timeout(90)
     public void testFindAll() throws ExecutionException, InterruptedException {
-        String connectionBeanRef = String.format("com.mongodb.client.MongoClients#create('mongodb://%s:%d')",
-                mongoDBService.getHost(),
-                mongoDBService.getPort());
+        String connectionBeanRef = String.format("com.mongodb.client.MongoClients#create('%s')",
+                mongoDBService.getReplicaSetUrl());
 
         ConnectorPropertyFactory factory = CamelMongoDBPropertyFactory.basic()
                 .withKafkaTopic(TestUtils.getDefaultTestTopic(this.getClass()))


### PR DESCRIPTION
We need to pass variable to the mongodb.host in format mongodb://user:pass@domain otherway:
[ERROR]   CamelSinkMongoDBITCase.setUp:63 » IllegalArgument The connection string is inv...
[ERROR]   CamelSourceMongoDBITCase.setUp:66 » IllegalArgument The connection string is i...

But if we pass in that format we receive mongodb://mongodb://user:pass@domain:port and:
[ERROR] Failures: 
[ERROR]   CamelSinkMongoDBITCase.testBasicSendReceive:120->runTest:100 Condition not met within timeout 30000. The connector CamelMongoDBSinkConnector did not start within a reasonable time
[ERROR] Errors: 
[ERROR]   CamelSourceMongoDBITCase.testFindAll » Timeout testFindAll() timed out after 9...

With that fix - test will pass (tested with remote mongodb)