### PR TITLE
Update try-it-out-on-openshift-with-strimzi.adoc with latest AWS S3 connector config

### DIFF
--- a/docs/modules/ROOT/pages/try-it-out-on-openshift-with-strimzi.adoc
+++ b/docs/modules/ROOT/pages/try-it-out-on-openshift-with-strimzi.adoc
@@ -112,9 +112,9 @@ oc exec -i -c kafka my-cluster-kafka-0 -- curl -X POST \
     "camel.source.path.bucketNameOrArn": "camel-connector-test",
     "camel.source.endpoint.autocloseBody": false,
     "camel.source.maxPollDuration": 10000,
-    "camel.component.aws-s3.configuration.access-key": "xxx",
-    "camel.component.aws-s3.configuration.secret-key": "xxx",
-    "camel.component.aws-s3.configuration.region": "xxx"
+    "camel.component.aws-s3.accessKey": "xxx",
+    "camel.component.aws-s3.secretKey": "xxx",
+    "camel.component.aws-s3.region": "xxx"
   }
 }
 EOF
@@ -142,9 +142,9 @@ spec:
     camel.source.path.bucketNameOrArn: camel-connector-test
     camel.source.endpoint.autocloseBody: false
     camel.source.maxPollDuration: 10000
-    camel.component.aws-s3.configuration.access-key: xxx
-    camel.component.aws-s3.configuration.secret-key: xxx
-    camel.component.aws-s3.configuration.region: xxx
+    camel.component.aws-s3.accessKey: xxx
+    camel.component.aws-s3.secretKey: xxx
+    camel.component.aws-s3.region: xxx
 EOF
 ----
 


### PR DESCRIPTION
Update the "Try it on OpenShift" doc on creating a connector instance to match the latest AWS S3 connector configuration in:
https://camel.apache.org/camel-kafka-connector/latest/connectors/camel-aws-s3-kafka-source-connector.html