### PR TITLE
CAMEL-15496: Headers and properties support

### DIFF
--- a/connectors/camel-rabbitmq-kafka-connector/src/main/docs/camel-rabbitmq-kafka-sink-connector.adoc
+++ b/connectors/camel-rabbitmq-kafka-connector/src/main/docs/camel-rabbitmq-kafka-sink-connector.adoc
@@ -54,6 +54,8 @@ The camel-rabbitmq sink connector supports 98 options, which are listed below.
 | *camel.sink.endpoint.vhost* | The vhost for the channel | "/" | MEDIUM
 | *camel.sink.endpoint.allowCustomHeaders* | Allow pass custom values to header | false | MEDIUM
 | *camel.sink.endpoint.allowNullHeaders* | Allow pass null values to header | false | MEDIUM
+| *camel.sink.endpoint.additionalHeaders* | Bean reference to set the additional headers. These headers will be set only when the 'allowCustomHeaders' is set to true | null | MEDIUM
+| *camel.sink.endpoint.additionalProperties* | Map of additional properties. These are standard RabbitMQ properties as defined in com.rabbitmq.client.AMQP.BasicProperties. The map keys should be from org.apache.camel.component.rabbitmq.RabbitMQConstants. Any other keys will be ignored. | null | MEDIUM
 | *camel.sink.endpoint.bridgeEndpoint* | If the bridgeEndpoint is true, the producer will ignore the message header of rabbitmq.EXCHANGE_NAME and rabbitmq.ROUTING_KEY | false | MEDIUM
 | *camel.sink.endpoint.channelPoolMaxSize* | Get maximum number of opened channel in pool | 10 | MEDIUM
 | *camel.sink.endpoint.channelPoolMaxWait* | Set the maximum number of milliseconds to wait for a channel from the pool | 1000L | MEDIUM
@@ -100,6 +102,8 @@ The camel-rabbitmq sink connector supports 98 options, which are listed below.
 | *camel.component.rabbitmq.skipQueueDeclare* | If true the producer will not declare and bind a queue. This can be used for directing messages via an existing routing key. | false | MEDIUM
 | *camel.component.rabbitmq.vhost* | The vhost for the channel | "/" | MEDIUM
 | *camel.component.rabbitmq.allowNullHeaders* | Allow pass null values to header | false | MEDIUM
+| *camel.component.rabbitmq.additionalHeaders* | Bean reference to set the additional headers. These headers will be set only when the 'allowCustomHeaders' is set to true | null | MEDIUM
+| *camel.component.rabbitmq.additionalProperties* | Map of additional properties. These are standard RabbitMQ properties as defined in com.rabbitmq.client.AMQP.BasicProperties. The map keys should be from org.apache.camel.component.rabbitmq.RabbitMQConstants. Any other keys will be ignored. | null | MEDIUM
 | *camel.component.rabbitmq.channelPoolMaxSize* | Get maximum number of opened channel in pool | 10 | MEDIUM
 | *camel.component.rabbitmq.channelPoolMaxWait* | Set the maximum number of milliseconds to wait for a channel from the pool | 1000L | MEDIUM
 | *camel.component.rabbitmq.guaranteedDeliveries* | When true, an exception will be thrown when the message cannot be delivered (basic.return) and the message is marked as mandatory. PublisherAcknowledgement will also be activated in this case. See also publisher acknowledgements - When will messages be confirmed. | false | MEDIUM

--- a/connectors/camel-rabbitmq-kafka-connector/src/main/java/org/apache/camel/kafkaconnector/rabbitmq/CamelRabbitmqSinkConnectorConfig.java
+++ b/connectors/camel-rabbitmq-kafka-connector/src/main/java/org/apache/camel/kafkaconnector/rabbitmq/CamelRabbitmqSinkConnectorConfig.java
@@ -101,6 +101,12 @@ public class CamelRabbitmqSinkConnectorConfig
     public static final String CAMEL_SINK_RABBITMQ_ENDPOINT_ALLOW_NULL_HEADERS_CONF = "camel.sink.endpoint.allowNullHeaders";
     public static final String CAMEL_SINK_RABBITMQ_ENDPOINT_ALLOW_NULL_HEADERS_DOC = "Allow pass null values to header";
     public static final Boolean CAMEL_SINK_RABBITMQ_ENDPOINT_ALLOW_NULL_HEADERS_DEFAULT = false;
+    public static final String CAMEL_SINK_RABBITMQ_ENDPOINT_ADDITIONAL_HEADERS_CONF = "camel.sink.endpoint.additionalHeaders";
+    public static final String CAMEL_SINK_RABBITMQ_ENDPOINT_ADDITIONAL_HEADERS_DOC = "Bean reference to set the additional headers. These headers will be set only when the 'allowCustomHeaders' is set to true";
+    public static final String CAMEL_SINK_RABBITMQ_ENDPOINT_ADDITIONAL_HEADERS_DEFAULT = null;
+    public static final String CAMEL_SINK_RABBITMQ_ENDPOINT_ADDITIONAL_PROPERTIES_CONF = "camel.sink.endpoint.additionalProperties";
+    public static final String CAMEL_SINK_RABBITMQ_ENDPOINT_ADDITIONAL_PROPERTIES_DOC = "Map of additional properties. These are standard RabbitMQ properties as defined in com.rabbitmq.client.AMQP.BasicProperties. The map keys should be from org.apache.camel.component.rabbitmq.RabbitMQConstants. Any other keys will be ignored.";
+    public static final String CAMEL_SINK_RABBITMQ_ENDPOINT_ADDITIONAL_PROPERTIES_DEFAULT = null;
     public static final String CAMEL_SINK_RABBITMQ_ENDPOINT_BRIDGE_ENDPOINT_CONF = "camel.sink.endpoint.bridgeEndpoint";
     public static final String CAMEL_SINK_RABBITMQ_ENDPOINT_BRIDGE_ENDPOINT_DOC = "If the bridgeEndpoint is true, the producer will ignore the message header of rabbitmq.EXCHANGE_NAME and rabbitmq.ROUTING_KEY";
     public static final Boolean CAMEL_SINK_RABBITMQ_ENDPOINT_BRIDGE_ENDPOINT_DEFAULT = false;
@@ -239,6 +245,12 @@ public class CamelRabbitmqSinkConnectorConfig
     public static final String CAMEL_SINK_RABBITMQ_COMPONENT_ALLOW_NULL_HEADERS_CONF = "camel.component.rabbitmq.allowNullHeaders";
     public static final String CAMEL_SINK_RABBITMQ_COMPONENT_ALLOW_NULL_HEADERS_DOC = "Allow pass null values to header";
     public static final Boolean CAMEL_SINK_RABBITMQ_COMPONENT_ALLOW_NULL_HEADERS_DEFAULT = false;
+    public static final String CAMEL_SINK_RABBITMQ_COMPONENT_ADDITIONAL_HEADERS_CONF = "camel.component.rabbitmq.additionalHeaders";
+    public static final String CAMEL_SINK_RABBITMQ_COMPONENT_ADDITIONAL_HEADERS_DOC = "Bean reference to set the additional headers. These headers will be set only when the 'allowCustomHeaders' is set to true.";
+    public static final String CAMEL_SINK_RABBITMQ_COMPONENT_ADDITIONAL_HEADERS_DEFAULT = null;
+    public static final String CAMEL_SINK_RABBITMQ_COMPONENT_ADDITIONAL_PROPERTIES_CONF = "camel.component.rabbitmq.additionalHeaders";
+    public static final String CAMEL_SINK_RABBITMQ_COMPONENT_ADDITIONAL_PROPERTIES_DOC = "Map of additional properties. These are standard RabbitMQ properties as defined in {@link com.rabbitmq.client.AMQP.BasicProperties}. The map keys should be from {@link org.apache.camel.component.rabbitmq.RabbitMQConstants}. Any other keys will be ignored.";
+    public static final String CAMEL_SINK_RABBITMQ_COMPONENT_ADDITIONAL_PROPERTIES_DEFAULT = null;
     public static final String CAMEL_SINK_RABBITMQ_COMPONENT_CHANNEL_POOL_MAX_SIZE_CONF = "camel.component.rabbitmq.channelPoolMaxSize";
     public static final String CAMEL_SINK_RABBITMQ_COMPONENT_CHANNEL_POOL_MAX_SIZE_DOC = "Get maximum number of opened channel in pool";
     public static final Integer CAMEL_SINK_RABBITMQ_COMPONENT_CHANNEL_POOL_MAX_SIZE_DEFAULT = 10;
@@ -358,6 +370,8 @@ public class CamelRabbitmqSinkConnectorConfig
         conf.define(CAMEL_SINK_RABBITMQ_ENDPOINT_VHOST_CONF, ConfigDef.Type.STRING, CAMEL_SINK_RABBITMQ_ENDPOINT_VHOST_DEFAULT, ConfigDef.Importance.MEDIUM, CAMEL_SINK_RABBITMQ_ENDPOINT_VHOST_DOC);
         conf.define(CAMEL_SINK_RABBITMQ_ENDPOINT_ALLOW_CUSTOM_HEADERS_CONF, ConfigDef.Type.BOOLEAN, CAMEL_SINK_RABBITMQ_ENDPOINT_ALLOW_CUSTOM_HEADERS_DEFAULT, ConfigDef.Importance.MEDIUM, CAMEL_SINK_RABBITMQ_ENDPOINT_ALLOW_CUSTOM_HEADERS_DOC);
         conf.define(CAMEL_SINK_RABBITMQ_ENDPOINT_ALLOW_NULL_HEADERS_CONF, ConfigDef.Type.BOOLEAN, CAMEL_SINK_RABBITMQ_ENDPOINT_ALLOW_NULL_HEADERS_DEFAULT, ConfigDef.Importance.MEDIUM, CAMEL_SINK_RABBITMQ_ENDPOINT_ALLOW_NULL_HEADERS_DOC);
+        conf.define(CAMEL_SINK_RABBITMQ_ENDPOINT_ADDITIONAL_HEADERS_CONF, ConfigDef.Type.STRING, CAMEL_SINK_RABBITMQ_ENDPOINT_ADDITIONAL_HEADERS_DEFAULT, ConfigDef.Importance.MEDIUM, CAMEL_SINK_RABBITMQ_ENDPOINT_ADDITIONAL_HEADERS_DOC);
+        conf.define(CAMEL_SINK_RABBITMQ_ENDPOINT_ADDITIONAL_PROPERTIES_CONF, ConfigDef.Type.STRING, CAMEL_SINK_RABBITMQ_ENDPOINT_ADDITIONAL_PROPERTIES_DEFAULT, ConfigDef.Importance.MEDIUM, CAMEL_SINK_RABBITMQ_ENDPOINT_ADDITIONAL_PROPERTIES_DOC);
         conf.define(CAMEL_SINK_RABBITMQ_ENDPOINT_BRIDGE_ENDPOINT_CONF, ConfigDef.Type.BOOLEAN, CAMEL_SINK_RABBITMQ_ENDPOINT_BRIDGE_ENDPOINT_DEFAULT, ConfigDef.Importance.MEDIUM, CAMEL_SINK_RABBITMQ_ENDPOINT_BRIDGE_ENDPOINT_DOC);
         conf.define(CAMEL_SINK_RABBITMQ_ENDPOINT_CHANNEL_POOL_MAX_SIZE_CONF, ConfigDef.Type.INT, CAMEL_SINK_RABBITMQ_ENDPOINT_CHANNEL_POOL_MAX_SIZE_DEFAULT, ConfigDef.Importance.MEDIUM, CAMEL_SINK_RABBITMQ_ENDPOINT_CHANNEL_POOL_MAX_SIZE_DOC);
         conf.define(CAMEL_SINK_RABBITMQ_ENDPOINT_CHANNEL_POOL_MAX_WAIT_CONF, ConfigDef.Type.LONG, CAMEL_SINK_RABBITMQ_ENDPOINT_CHANNEL_POOL_MAX_WAIT_DEFAULT, ConfigDef.Importance.MEDIUM, CAMEL_SINK_RABBITMQ_ENDPOINT_CHANNEL_POOL_MAX_WAIT_DOC);

--- a/core/src/main/java/org/apache/camel/kafkaconnector/CamelSinkTask.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/CamelSinkTask.java
@@ -140,7 +140,7 @@ public class CamelSinkTask extends SinkTask {
             exchange.getMessage().setHeaders(headers);
             exchange.getMessage().setBody(record.value());
 
-            LOG.debug("Sending exchange {} to {}", exchange.getExchangeId(), LOCAL_URL);
+            LOG.info("Sending exchange {} to {}", exchange.getExchangeId(), LOCAL_URL);
             producer.send(LOCAL_URL, exchange);
 
             if (exchange.isFailed()) {


### PR DESCRIPTION
The additional headers will be added on top of the existing headers
from the message.

The properties added are only basic AMQP properties as defined in the
{@link com.rabbitmq.client.AMQP.BasicProperties.Builder}. When the
message contains already these properties then will be considered and
these additional properties will be ignored.