### PR TITLE
Add an integration test for the archetype

### DIFF
--- a/archetypes/camel-kafka-connector-extensible-archetype/src/test/resources/projects/camel-timer-kafka-connector/archetype.properties
+++ b/archetypes/camel-kafka-connector-extensible-archetype/src/test/resources/projects/camel-timer-kafka-connector/archetype.properties
@@ -1,0 +1,26 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+sourceEncoding=UTF-8
+archetype.groupId=org.apache.camel.kafkaconnector.archetypes
+archetype.artifactId=camel-kafka-connector-extensible-archetype
+groupId=org.apache.camel.kafka-connector.test
+artifactId=timer
+
+version=1.0.0-SNAPSHOT
+camel-kafka-connector-version=0.5.0
+camel-kafka-connector-name=camel-timer-kafka-connector

--- a/archetypes/camel-kafka-connector-extensible-archetype/src/test/resources/projects/camel-timer-kafka-connector/goal.txt
+++ b/archetypes/camel-kafka-connector-extensible-archetype/src/test/resources/projects/camel-timer-kafka-connector/goal.txt
@@ -1,0 +1,1 @@
+install


### PR DESCRIPTION
#462 Add an integration test for the archetype, using maven archetype's built in integration-tests functionality (https://maven.apache.org/archetype/maven-archetype-plugin/integration-test-mojo.html) 

I tried getting a `reference` to work as well to test the maven archetype results against expected results, but it seems to be expecting us to generate java code and is generating a `src/main/java/null`.   Not sure how to get around that, but this at least tests whether the archetype:generate succeeds / whether the results build.
