### PR TITLE
Clean up usages of org.junit.Assert

### DIFF
--- a/tests/itests-common/src/test/java/org/apache/camel/kafkaconnector/common/services/kafkaconnect/KafkaConnectRunnerService.java
+++ b/tests/itests-common/src/test/java/org/apache/camel/kafkaconnector/common/services/kafkaconnect/KafkaConnectRunnerService.java
@@ -31,7 +31,7 @@ import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class KafkaConnectRunnerService implements KafkaConnectService {
     private static final Logger LOG = LoggerFactory.getLogger(KafkaConnectRunnerService.class);

--- a/tests/itests-common/src/test/java/org/apache/camel/kafkaconnector/common/utils/PropertyUtils.java
+++ b/tests/itests-common/src/test/java/org/apache/camel/kafkaconnector/common/utils/PropertyUtils.java
@@ -23,9 +23,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 public final class PropertyUtils {
     private static final Logger LOG = LoggerFactory.getLogger(PropertyUtils.class);
@@ -56,12 +57,12 @@ public final class PropertyUtils {
             LOG.error("Test properties provided at {} does not exist, therefore aborting the test execution",
                     fileName);
 
-            Assert.fail("The given test properties file does not exist");
+            fail("The given test properties file does not exist");
         } catch (IOException e) {
             LOG.error("I/O error reading the test properties at {}: {}",
                     fileName, e.getMessage(), e);
 
-            Assert.fail("Unable to read the test properties file");
+            fail("Unable to read the test properties file");
         }
     }
 }

--- a/tests/itests-syslog/src/test/java/org/apache/camel/kafkaconnector/syslog/sink/CamelSinkSyslogITCase.java
+++ b/tests/itests-syslog/src/test/java/org/apache/camel/kafkaconnector/syslog/sink/CamelSinkSyslogITCase.java
@@ -30,7 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 


### PR DESCRIPTION
The project standard is to use `org.junit.jupiter.api.Assertions` for assertions, but there are several instances where the older `org.junit.Assert` is used, in what seems to be an oversight.

This patch cleans up those usages, and standardizes them to use `org.junit.jupiter.api.Assertions`, like the rest of the project.