### PR TITLE
Do not use the wrapper test client on the AWS service classes

### DIFF
--- a/tests/itests-aws-v1/src/test/java/org/apache/camel/kafkaconnector/aws/v1/services/AWSRemoteService.java
+++ b/tests/itests-aws-v1/src/test/java/org/apache/camel/kafkaconnector/aws/v1/services/AWSRemoteService.java
@@ -23,11 +23,8 @@ import java.util.function.Supplier;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.regions.Regions;
-import com.amazonaws.services.sqs.AmazonSQS;
 import org.apache.camel.kafkaconnector.aws.common.AWSConfigs;
 import org.apache.camel.kafkaconnector.aws.common.services.AWSService;
-import org.apache.camel.kafkaconnector.aws.v1.clients.AWSClientUtils;
-import org.apache.camel.kafkaconnector.aws.v1.clients.AWSSQSClient;
 import org.apache.camel.kafkaconnector.aws.v1.common.TestAWSCredentialsProvider;
 
 public class AWSRemoteService<T> implements AWSService<T> {
@@ -70,12 +67,4 @@ public class AWSRemoteService<T> implements AWSService<T> {
     public void shutdown() {
 
     }
-
-    public static AWSSQSClient newSQSClient() {
-        AmazonSQS sqs = AWSClientUtils.newSQSClient();
-
-        return new AWSSQSClient(sqs);
-    }
-
-
 }

--- a/tests/itests-aws-v1/src/test/java/org/apache/camel/kafkaconnector/aws/v1/services/AWSSNSLocalContainerService.java
+++ b/tests/itests-aws-v1/src/test/java/org/apache/camel/kafkaconnector/aws/v1/services/AWSSNSLocalContainerService.java
@@ -19,10 +19,9 @@ package org.apache.camel.kafkaconnector.aws.v1.services;
 
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
-import org.apache.camel.kafkaconnector.aws.v1.clients.AWSSQSClient;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 
-public class AWSSNSLocalContainerService extends AWSLocalContainerService<AWSSQSClient> {
+public class AWSSNSLocalContainerService extends AWSLocalContainerService<AmazonSQS> {
 
     public AWSSNSLocalContainerService() {
         super(LocalStackContainer.Service.SQS,
@@ -43,14 +42,12 @@ public class AWSSNSLocalContainerService extends AWSLocalContainerService<AWSSQS
 
 
     @Override
-    public AWSSQSClient getClient() {
-        AmazonSQS sqs = AmazonSQSClientBuilder
+    public AmazonSQS getClient() {
+        return AmazonSQSClientBuilder
                 .standard()
                 .withEndpointConfiguration(getContainer()
                         .getEndpointConfiguration(LocalStackContainer.Service.SQS))
                 .withCredentials(getContainer().getDefaultCredentialsProvider())
                 .build();
-
-        return new AWSSQSClient(sqs);
     }
 }

--- a/tests/itests-aws-v1/src/test/java/org/apache/camel/kafkaconnector/aws/v1/services/AWSSQSLocalContainerService.java
+++ b/tests/itests-aws-v1/src/test/java/org/apache/camel/kafkaconnector/aws/v1/services/AWSSQSLocalContainerService.java
@@ -19,10 +19,9 @@ package org.apache.camel.kafkaconnector.aws.v1.services;
 
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
-import org.apache.camel.kafkaconnector.aws.v1.clients.AWSSQSClient;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 
-public class AWSSQSLocalContainerService extends AWSLocalContainerService<AWSSQSClient> {
+public class AWSSQSLocalContainerService extends AWSLocalContainerService<AmazonSQS> {
 
     public AWSSQSLocalContainerService() {
         super(LocalStackContainer.Service.SQS);
@@ -41,14 +40,12 @@ public class AWSSQSLocalContainerService extends AWSLocalContainerService<AWSSQS
     }
 
     @Override
-    public AWSSQSClient getClient() {
-        AmazonSQS sqs = AmazonSQSClientBuilder
+    public AmazonSQS getClient() {
+        return AmazonSQSClientBuilder
                 .standard()
                 .withEndpointConfiguration(getContainer()
                         .getEndpointConfiguration(LocalStackContainer.Service.SQS))
                 .withCredentials(getContainer().getDefaultCredentialsProvider())
                 .build();
-
-        return new AWSSQSClient(sqs);
     }
 }

--- a/tests/itests-aws-v1/src/test/java/org/apache/camel/kafkaconnector/aws/v1/services/AWSServiceFactory.java
+++ b/tests/itests-aws-v1/src/test/java/org/apache/camel/kafkaconnector/aws/v1/services/AWSServiceFactory.java
@@ -19,9 +19,9 @@ package org.apache.camel.kafkaconnector.aws.v1.services;
 
 import com.amazonaws.services.kinesis.AmazonKinesis;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.sqs.AmazonSQS;
 import org.apache.camel.kafkaconnector.aws.common.services.AWSService;
 import org.apache.camel.kafkaconnector.aws.v1.clients.AWSClientUtils;
-import org.apache.camel.kafkaconnector.aws.v1.clients.AWSSQSClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +35,7 @@ public final class AWSServiceFactory {
         return awsInstanceType == null ? "default" : awsInstanceType;
     }
 
-    public static AWSService<AWSSQSClient> createSQSService() {
+    public static AWSService<AmazonSQS> createSQSService() {
         String awsInstanceType = System.getProperty("aws-service.instance.type");
         LOG.info("Creating a {} AWS SQS instance", getInstanceTypeName(awsInstanceType));
 
@@ -44,7 +44,7 @@ public final class AWSServiceFactory {
         }
 
         if (awsInstanceType.equals("remote")) {
-            return new AWSRemoteService<>(AWSRemoteService::newSQSClient);
+            return new AWSRemoteService<>(AWSClientUtils::newSQSClient);
         }
 
         LOG.error("Invalid AWS instance type: {}. Must be either 'remote' or 'local-aws-container'",
@@ -53,7 +53,7 @@ public final class AWSServiceFactory {
     }
 
 
-    public static AWSService<AWSSQSClient> createSNSService() {
+    public static AWSService<AmazonSQS> createSNSService() {
         String awsInstanceType = System.getProperty("aws-service.instance.type");
         LOG.info("Creating a {} AWS SNS instance", getInstanceTypeName(awsInstanceType));
 
@@ -62,7 +62,7 @@ public final class AWSServiceFactory {
         }
 
         if (awsInstanceType.equals("remote")) {
-            return new AWSRemoteService<>(AWSRemoteService::newSQSClient);
+            return new AWSRemoteService<>(AWSClientUtils::newSQSClient);
         }
 
         LOG.error("Invalid AWS instance type: {}. Must be either 'remote' or 'local-aws-container'",

--- a/tests/itests-aws-v1/src/test/java/org/apache/camel/kafkaconnector/aws/v1/sns/sink/CamelSinkAWSSNSITCase.java
+++ b/tests/itests-aws-v1/src/test/java/org/apache/camel/kafkaconnector/aws/v1/sns/sink/CamelSinkAWSSNSITCase.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import com.amazonaws.regions.Regions;
+import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.Message;
 import org.apache.camel.kafkaconnector.aws.common.AWSCommon;
 import org.apache.camel.kafkaconnector.aws.common.AWSConfigs;
@@ -51,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 @Testcontainers
 public class CamelSinkAWSSNSITCase extends AbstractKafkaTest  {
     @RegisterExtension
-    public static AWSService<AWSSQSClient> service = AWSServiceFactory.createSNSService();
+    public static AWSService<AmazonSQS> service = AWSServiceFactory.createSNSService();
 
     private static final Logger LOG = LoggerFactory.getLogger(CamelSinkAWSSNSITCase.class);
 
@@ -69,7 +70,7 @@ public class CamelSinkAWSSNSITCase extends AbstractKafkaTest  {
 
     @BeforeEach
     public void setUp() {
-        awsSqsClient = service.getClient();
+        awsSqsClient = new AWSSQSClient(service.getClient());
 
         queueName = AWSCommon.DEFAULT_SQS_QUEUE_FOR_SNS + "-" + TestUtils.randomWithRange(0, 1000);
         sqsQueueUrl = awsSqsClient.getQueue(queueName);

--- a/tests/itests-aws-v1/src/test/java/org/apache/camel/kafkaconnector/aws/v1/sqs/sink/CamelSinkAWSSQSITCase.java
+++ b/tests/itests-aws-v1/src/test/java/org/apache/camel/kafkaconnector/aws/v1/sqs/sink/CamelSinkAWSSQSITCase.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import com.amazonaws.regions.Regions;
+import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.Message;
 import org.apache.camel.kafkaconnector.aws.common.AWSCommon;
 import org.apache.camel.kafkaconnector.aws.common.AWSConfigs;
@@ -52,7 +53,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 @Testcontainers
 public class CamelSinkAWSSQSITCase extends AbstractKafkaTest {
     @RegisterExtension
-    public static AWSService<AWSSQSClient> awsService = AWSServiceFactory.createSQSService();
+    public static AWSService<AmazonSQS> awsService = AWSServiceFactory.createSQSService();
 
     private static final Logger LOG = LoggerFactory.getLogger(CamelSinkAWSSQSITCase.class);
 
@@ -70,7 +71,7 @@ public class CamelSinkAWSSQSITCase extends AbstractKafkaTest {
 
     @BeforeEach
     public void setUp() {
-        awssqsClient = awsService.getClient();
+        awssqsClient = new AWSSQSClient(awsService.getClient());
 
         queueName = AWSCommon.BASE_SQS_QUEUE_NAME + "-" + TestUtils.randomWithRange(0, 1000);
         queueUrl = awssqsClient.getQueue(queueName);

--- a/tests/itests-aws-v1/src/test/java/org/apache/camel/kafkaconnector/aws/v1/sqs/source/CamelSourceAWSSQSITCase.java
+++ b/tests/itests-aws-v1/src/test/java/org/apache/camel/kafkaconnector/aws/v1/sqs/source/CamelSourceAWSSQSITCase.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 
 import com.amazonaws.regions.Regions;
+import com.amazonaws.services.sqs.AmazonSQS;
 import org.apache.camel.kafkaconnector.aws.common.AWSCommon;
 import org.apache.camel.kafkaconnector.aws.common.AWSConfigs;
 import org.apache.camel.kafkaconnector.aws.common.services.AWSService;
@@ -47,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 @Testcontainers
 public class CamelSourceAWSSQSITCase extends AbstractKafkaTest {
     @RegisterExtension
-    public static AWSService<AWSSQSClient> service = AWSServiceFactory.createSQSService();
+    public static AWSService<AmazonSQS> service = AWSServiceFactory.createSQSService();
 
     private static final Logger LOG = LoggerFactory.getLogger(CamelSourceAWSSQSITCase.class);
 
@@ -65,7 +66,7 @@ public class CamelSourceAWSSQSITCase extends AbstractKafkaTest {
 
     @BeforeEach
     public void setUp() {
-        awssqsClient = service.getClient();
+        awssqsClient = new AWSSQSClient(service.getClient());
         queueName = AWSCommon.BASE_SQS_QUEUE_NAME + "-" + TestUtils.randomWithRange(0, 1000);
 
         queueUrl = awssqsClient.getQueue(queueName);


### PR DESCRIPTION
Minor cleanup to simplifying migrating to the reusable infra in Camel when we migrate