### PR TITLE
Remove static access to CamelKafkaConnectorCatalog.getConnectorsModel()

### DIFF
--- a/camel-kafka-connector-catalog/src/main/java/org/apache/camel/kafkaconnector/catalog/CamelKafkaConnectorCatalog.java
+++ b/camel-kafka-connector-catalog/src/main/java/org/apache/camel/kafkaconnector/catalog/CamelKafkaConnectorCatalog.java
@@ -132,7 +132,7 @@ public class CamelKafkaConnectorCatalog {
         return connectorsName;
     }
 
-    public static Map<String, CamelKafkaConnectorModel> getConnectorsModel() {
+    public Map<String, CamelKafkaConnectorModel> getConnectorsModel() {
         return connectorsModel;
     }
 }


### PR DESCRIPTION
the class needs to be instantiated to have model initialized

Signed-off-by: Aurélien Pupier <apupier@redhat.com>