### PR TITLE
Do not use the wrapper test client on the AWS v2 service classes

### DIFF
--- a/tests/itests-aws-v2/src/test/java/org/apache/camel/kafkaconnector/aws/v2/clients/AWSSDKClientUtils.java
+++ b/tests/itests-aws-v2/src/test/java/org/apache/camel/kafkaconnector/aws/v2/clients/AWSSDKClientUtils.java
@@ -87,7 +87,7 @@ public final class AWSSDKClientUtils {
         return clientBuilder.build();
     }
 
-    public static AWSSQSClient newSQSClient() {
+    public static SqsClient newSQSClient() {
         LOG.debug("Creating a new AWS v2 SQS client");
 
         String awsInstanceType = System.getProperty("aws-service.instance.type");
@@ -109,7 +109,7 @@ public final class AWSSDKClientUtils {
             clientBuilder.credentialsProvider(TestAWSCredentialsProvider.SYSTEM_PROPERTY_PROVIDER);
         }
 
-        return new AWSSQSClient(clientBuilder.build());
+        return clientBuilder.build();
     }
 
     public static S3Client newS3Client() {

--- a/tests/itests-aws-v2/src/test/java/org/apache/camel/kafkaconnector/aws/v2/services/AWSSQSLocalContainerService.java
+++ b/tests/itests-aws-v2/src/test/java/org/apache/camel/kafkaconnector/aws/v2/services/AWSSQSLocalContainerService.java
@@ -17,14 +17,13 @@
 
 package org.apache.camel.kafkaconnector.aws.v2.services;
 
-import org.apache.camel.kafkaconnector.aws.v2.clients.AWSSQSClient;
 import org.apache.camel.kafkaconnector.aws.v2.common.TestAWSCredentialsProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsClient;
 
-public class AWSSQSLocalContainerService extends AWSLocalContainerService<AWSSQSClient> {
+public class AWSSQSLocalContainerService extends AWSLocalContainerService<SqsClient> {
     private static final Logger LOG = LoggerFactory.getLogger(AWSSQSLocalContainerService.class);
 
     public AWSSQSLocalContainerService() {
@@ -37,15 +36,13 @@ public class AWSSQSLocalContainerService extends AWSLocalContainerService<AWSSQS
     }
 
     @Override
-    public AWSSQSClient getClient() {
+    public SqsClient getClient() {
         Region region = Region.US_EAST_1;
 
-        SqsClient client = SqsClient.builder()
+        return SqsClient.builder()
                 .region(region)
                 .credentialsProvider(TestAWSCredentialsProvider.CONTAINER_LOCAL_DEFAULT_PROVIDER)
                 .endpointOverride(getServiceEndpoint())
                 .build();
-
-        return new AWSSQSClient(client);
     }
 }

--- a/tests/itests-aws-v2/src/test/java/org/apache/camel/kafkaconnector/aws/v2/services/AWSServiceFactory.java
+++ b/tests/itests-aws-v2/src/test/java/org/apache/camel/kafkaconnector/aws/v2/services/AWSServiceFactory.java
@@ -19,12 +19,12 @@ package org.apache.camel.kafkaconnector.aws.v2.services;
 
 import org.apache.camel.kafkaconnector.aws.common.services.AWSService;
 import org.apache.camel.kafkaconnector.aws.v2.clients.AWSSDKClientUtils;
-import org.apache.camel.kafkaconnector.aws.v2.clients.AWSSQSClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.services.kinesis.KinesisClient;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.sqs.SqsClient;
 
 public final class AWSServiceFactory {
     private static final Logger LOG = LoggerFactory.getLogger(AWSServiceFactory.class);
@@ -58,7 +58,7 @@ public final class AWSServiceFactory {
         throw new UnsupportedOperationException("Invalid AWS instance type");
     }
 
-    public static AWSService<AWSSQSClient> createSQSService() {
+    public static AWSService<SqsClient> createSQSService() {
         String awsInstanceType = System.getProperty("aws-service.instance.type");
         LOG.info("Creating a {} AWS SQS instance", getInstanceTypeName(awsInstanceType));
 

--- a/tests/itests-aws-v2/src/test/java/org/apache/camel/kafkaconnector/aws/v2/sqs/sink/CamelSinkAWSSQSITCase.java
+++ b/tests/itests-aws-v2/src/test/java/org/apache/camel/kafkaconnector/aws/v2/sqs/sink/CamelSinkAWSSQSITCase.java
@@ -45,6 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.Message;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -54,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 @Testcontainers
 public class CamelSinkAWSSQSITCase extends AbstractKafkaTest {
     @RegisterExtension
-    public static AWSService<AWSSQSClient> awsService = AWSServiceFactory.createSQSService();
+    public static AWSService<SqsClient> awsService = AWSServiceFactory.createSQSService();
 
     private static final Logger LOG = LoggerFactory.getLogger(CamelSinkAWSSQSITCase.class);
 
@@ -72,7 +73,7 @@ public class CamelSinkAWSSQSITCase extends AbstractKafkaTest {
 
     @BeforeEach
     public void setUp() {
-        awssqsClient = awsService.getClient();
+        awssqsClient = new AWSSQSClient(awsService.getClient());
 
         queueName = AWSCommon.BASE_SQS_QUEUE_NAME + "-" + TestUtils.randomWithRange(0, 1000);
         String queueUrl = awssqsClient.getOrCreateQueue(queueName);

--- a/tests/itests-aws-v2/src/test/java/org/apache/camel/kafkaconnector/aws/v2/sqs/source/CamelSourceAWSSQSITCase.java
+++ b/tests/itests-aws-v2/src/test/java/org/apache/camel/kafkaconnector/aws/v2/sqs/source/CamelSourceAWSSQSITCase.java
@@ -41,6 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -49,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 @Testcontainers
 public class CamelSourceAWSSQSITCase extends AbstractKafkaTest {
     @RegisterExtension
-    public static AWSService<AWSSQSClient> service = AWSServiceFactory.createSQSService();
+    public static AWSService<SqsClient> service = AWSServiceFactory.createSQSService();
 
     private static final Logger LOG = LoggerFactory.getLogger(CamelSourceAWSSQSITCase.class);
 
@@ -66,7 +67,7 @@ public class CamelSourceAWSSQSITCase extends AbstractKafkaTest {
 
     @BeforeEach
     public void setUp() {
-        awssqsClient = service.getClient();
+        awssqsClient = new AWSSQSClient(service.getClient());
         queueName = AWSCommon.BASE_SQS_QUEUE_NAME + "-" + TestUtils.randomWithRange(0, 1000);
         received = 0;
     }


### PR DESCRIPTION
Another cleanup to simplify moving some of the code to Camel