### PR TITLE
Avoid usage of static for Camel Kafka Connector catalog

### DIFF
--- a/camel-kafka-connector-catalog/src/main/java/org/apache/camel/kafkaconnector/catalog/CamelKafkaConnectorCatalog.java
+++ b/camel-kafka-connector-catalog/src/main/java/org/apache/camel/kafkaconnector/catalog/CamelKafkaConnectorCatalog.java
@@ -39,12 +39,13 @@ import org.slf4j.LoggerFactory;
 
 public class CamelKafkaConnectorCatalog {
 
-    static List<String> connectorsName = new ArrayList<>();
-    static Map<String, CamelKafkaConnectorModel> connectorsModel = new HashMap<>();
     private static final Logger LOG = LoggerFactory.getLogger(CamelKafkaConnectorCatalog.class);
     private static final String CONNECTORS_DIR = "connectors";
     private static final String DESCRIPTORS_DIR = "descriptors";
     private static final String CONNECTORS_PROPERTIES = "connectors.properties";
+
+    private List<String> connectorsName = new ArrayList<>();
+    private Map<String, CamelKafkaConnectorModel> connectorsModel = new HashMap<>();
 
     public CamelKafkaConnectorCatalog() {
         initCatalog();


### PR DESCRIPTION
it will allow to use several version of the catalog in the same JVM.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>