### PR TITLE
Updated the mvnd command on the readme

### DIFF
--- a/docs/modules/ROOT/pages/contributing.adoc
+++ b/docs/modules/ROOT/pages/contributing.adoc
@@ -190,7 +190,7 @@ To build the project using `mvnd` instead of Maven, use the following command:
 
 [source,bash]
 ----
-mvnd -DskipIntegrationTests=true clean install
+mvnd -Darchetype.test.skip -DskipIntegrationTests=true clean install
 ----
 
 *Troubleshooting*:


### PR DESCRIPTION
The archetype test does not work with mvnd therefore it must be skipped

Related to #598