### PR TITLE
Update azure-tests

### DIFF
--- a/tests/itests-azure-storage-blob/src/test/java/org/apache/camel/kafkaconnector/azure/storage/services/AzureStorageBlobClientUtils.java
+++ b/tests/itests-azure-storage-blob/src/test/java/org/apache/camel/kafkaconnector/azure/storage/services/AzureStorageBlobClientUtils.java
@@ -46,7 +46,7 @@ public final class AzureStorageBlobClientUtils {
             endpoint = String.format("http://%s:%s/%s", host, port, accountName);
         } else {
             if (host == null || host.isEmpty()) {
-                endpoint = String.format("https://%s.queue.core.windows.net/%s", accountName, accountKey);
+                endpoint = String.format("https://%s.blob.core.windows.net/%s", accountName, accountKey);
             } else {
                 endpoint = String.format("http://%s:%s/%s", host, port, accountName);
             }

--- a/tests/itests-azure-storage-queue/src/test/java/org/apache/camel/kafkaconnector/azure/storage/queue/sink/CamelSinkAzureStorageQueueITCase.java
+++ b/tests/itests-azure-storage-queue/src/test/java/org/apache/camel/kafkaconnector/azure/storage/queue/sink/CamelSinkAzureStorageQueueITCase.java
@@ -35,7 +35,6 @@ import org.apache.camel.kafkaconnector.common.clients.kafka.KafkaClient;
 import org.apache.camel.kafkaconnector.common.utils.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -128,7 +127,6 @@ public class CamelSinkAzureStorageQueueITCase extends AbstractKafkaTest {
     }
 
 
-    @Disabled("Disabled due to issue #409")
     @Test
     @Timeout(90)
     public void testBasicSendReceive() throws InterruptedException, ExecutionException, IOException {


### PR DESCRIPTION
Hello, I have prepared some updates for azure-tests (mainly for blob)

1) fixed endpoint link
2) Consume function updated with retries loop due the fact of not instant response from real Azure service
3) Added verification of messages content
4) Added teardown function
5) Kindly ask you to review issue #409, it seems to me that everything is Ok for now.