### PR TITLE
Provide API to retrieve Basic configuration #679

### DIFF
--- a/camel-kafka-connector-catalog/pom.xml
+++ b/camel-kafka-connector-catalog/pom.xml
@@ -51,6 +51,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.kafkaconnector</groupId>
+            <artifactId>camel-kafka-connector</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.kafkaconnector</groupId>
             <artifactId>connectors</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
@@ -59,6 +64,14 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core-catalog</artifactId>
             <version>${camel.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+        <dependency>
+              <groupId>org.apache.kafka</groupId>
+              <artifactId>connect-api</artifactId>
         </dependency>
         <!-- logging -->
         <dependency>

--- a/camel-kafka-connector-catalog/src/main/java/org/apache/camel/kafkaconnector/catalog/CamelKafkaConnectorCatalog.java
+++ b/camel-kafka-connector-catalog/src/main/java/org/apache/camel/kafkaconnector/catalog/CamelKafkaConnectorCatalog.java
@@ -31,10 +31,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.camel.kafkaconnector.CamelSinkConnectorConfig;
+import org.apache.camel.kafkaconnector.CamelSourceConnectorConfig;
 import org.apache.camel.kafkaconnector.model.CamelKafkaConnectorModel;
 import org.apache.camel.kafkaconnector.model.CamelKafkaConnectorOptionModel;
 import org.apache.camel.tooling.model.JsonMapper;
 import org.apache.camel.util.json.JsonObject;
+import org.apache.kafka.common.config.ConfigDef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -180,5 +183,13 @@ public class CamelKafkaConnectorCatalog {
     public void removeConnector(String connectorName) {
         connectorsName.remove(connectorName);
         connectorsModel.remove(connectorName);
+    }
+
+    public ConfigDef getBasicConfigurationForSink() {
+        return CamelSinkConnectorConfig.conf();
+    }
+    
+    public ConfigDef getBasicConfigurationForSource() {
+        return CamelSourceConnectorConfig.conf();
     }
 }

--- a/camel-kafka-connector-catalog/src/test/java/org/apache/camel/kafkaconnector/catalog/CamelKafkaConnectorCatalogTest.java
+++ b/camel-kafka-connector-catalog/src/test/java/org/apache/camel/kafkaconnector/catalog/CamelKafkaConnectorCatalogTest.java
@@ -19,8 +19,13 @@ package org.apache.camel.kafkaconnector.catalog;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.camel.kafkaconnector.CamelSinkConnectorConfig;
+import org.apache.camel.kafkaconnector.CamelSourceConnectorConfig;
 import org.apache.camel.kafkaconnector.model.CamelKafkaConnectorModel;
 import org.apache.camel.kafkaconnector.model.CamelKafkaConnectorOptionModel;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.ConfigKey;
+import org.apache.kafka.common.config.ConfigDef.Type;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -167,6 +172,24 @@ class CamelKafkaConnectorCatalogTest {
         Map<String, CamelKafkaConnectorModel> p = catalog.getConnectorsModel();
         CamelKafkaConnectorModel model = p.get("camel-aws2-s3-sink");
         assertEquals("Store and retrieve objects from AWS S3 Storage Service using AWS SDK version 2.x.", model.getDescription());
+    }
+    
+    @Test
+    void testBasicConfigurationForSink() throws Exception {
+        ConfigDef sinkConfigDef = catalog.getBasicConfigurationForSink();
+        ConfigKey marshalConfigKey = sinkConfigDef.configKeys().get(CamelSinkConnectorConfig.CAMEL_SINK_MARSHAL_CONF);
+        assertEquals(CamelSinkConnectorConfig.CAMEL_SINK_MARSHAL_CONF, marshalConfigKey.name);
+        assertEquals(CamelSinkConnectorConfig.CAMEL_SINK_MARSHAL_DOC, marshalConfigKey.documentation);
+        assertEquals(Type.STRING, marshalConfigKey.type);
+    }
+    
+    @Test
+    void testBasicConfigurationForSource() throws Exception {
+        ConfigDef sourceConfigDef = catalog.getBasicConfigurationForSource();
+        ConfigKey marshalConfigKey = sourceConfigDef.configKeys().get(CamelSourceConnectorConfig.CAMEL_SOURCE_MARSHAL_CONF);
+        assertEquals(CamelSourceConnectorConfig.CAMEL_SOURCE_MARSHAL_CONF, marshalConfigKey.name);
+        assertEquals(CamelSourceConnectorConfig.CAMEL_SOURCE_MARSHAL_DOC, marshalConfigKey.documentation);
+        assertEquals(Type.STRING, marshalConfigKey.type);
     }
 
 }


### PR DESCRIPTION
- it is exposing Camel Kafka APIs
- it requires then to add explicitly dependencies on kafka-clients and
connect-api as they are marked as "provided" for camel-kafka-connector

Signed-off-by: Aurélien Pupier <apupier@redhat.com>