### PR TITLE
Adjust the emdedded Kafka service to the updated interface from Camel 3.7

### DIFF
--- a/tests/itests-common/src/test/java/org/apache/camel/kafkaconnector/common/services/kafka/EmbeddedKafkaService.java
+++ b/tests/itests-common/src/test/java/org/apache/camel/kafkaconnector/common/services/kafka/EmbeddedKafkaService.java
@@ -79,11 +79,17 @@ public class EmbeddedKafkaService implements KafkaService {
     }
 
     @Override
+    public void registerProperties() {
+        // NO-OP
+    }
+
+    @Override
     public void initialize() {
         if (!started) {
             cluster.start();
             started = true;
 
+            registerProperties();
             LOG.info("Kafka bootstrap server running at address {}", getBootstrapServers());
         }
     }


### PR DESCRIPTION
The embedded Kafka needs a small adjustment, otherwise it fails to build