### PR TITLE
Set JMS clients scope runtime to include required dependencies in the package

### DIFF
--- a/connectors/camel-kafka-connector-fix-dependencies.properties
+++ b/connectors/camel-kafka-connector-fix-dependencies.properties
@@ -21,10 +21,7 @@
 # Global dependencies included in all modules (except the ones in the list)
 global=org.apache.camel.kafkaconnector:camel-kafka-connector
 
-# we add a default connection factory maven dependency (variables can be used as ${varname})
-camel-sjms2=org.apache.activemq:activemq-client,org.apache.activemq:artemis-jms-client
+# we add a default connection factory maven variables can be used as ${varname}
+camel-sjms2=org.apache.activemq:activemq-client::runtime,org.apache.activemq:artemis-jms-client::runtime
 exclude_camel-sjms2=
 additional_properties_camel-sjms2=camel.component.sjms2.connection-factory=#class:org.apache.activemq.ActiveMQConnectionFactory,camel.component.sjms2.connection-factory.brokerURL=tcp://localhost:61616
-
-# issue 259: https://github.com/apache/camel-kafka-connector/issues/259
-camel-elasticsearch-rest=org.slf4j:log4j-over-slf4j

--- a/connectors/camel-sjms2-kafka-connector/pom.xml
+++ b/connectors/camel-sjms2-kafka-connector/pom.xml
@@ -48,10 +48,12 @@
     <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>activemq-client</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-jms-client</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.kafkaconnector</groupId>

--- a/docs/modules/ROOT/pages/troubleshooting.adoc
+++ b/docs/modules/ROOT/pages/troubleshooting.adoc
@@ -3,7 +3,6 @@
 
 This page describes some common pitfalls when deploying the connectors.
 
-
 [[Troubleshooting-Contents]]
 == Table of Contents
 
@@ -32,7 +31,6 @@ connectors, it would be possible to have a directory structure like this:
 * `/camel-kafka-connectors/camel-hdfs-kafka-connector`
 * `/camel-kafka-connectors/camel-amqp-kafka-connector`
 
-
 [#missing-or-incorrect-converters]
 == Missing or Incorrect Converters
 
@@ -47,7 +45,6 @@ Here's one example with trying to exchange data using the AMQP connector without
 
 `Caused by: org.apache.kafka.connect.errors.DataException: JsonConverter with schemas.enable requires "schema" and "payload" fields and may not contain additional fields. If you are trying to deserialize plain JSON data, set schemas.enable=false in your converter configuration.`
 
-
 [#missing-dependencies]
 == Missing Dependencies
 
@@ -55,10 +52,9 @@ When deploying the connector manually (ie.: without the assistance of tools such
 make sure to provide the required runtime dependencies and their dependencies. Some notable examples are:
 
 * AMQP connector requires a JMS-compliant client (such as qpid-jms-client)
-* SJMS2 connector requires the client libraries for the protocol used to communicate with the broker (ie.:
-qpid-jms-client, activemq-client, artemis-jms-client, etc).
+* From version 0.7.0 onward, the ActiveMQ and Artemis JMS clients are packaged along with the SJMS2 connector.
+If you need to use other JMS clients, then you have to repackage including all required libraries.
 * JDBC connector requires the JDBC client for the database
-
 
 [#known-incompatibilities]
 == Known Incompatibilities

--- a/docs/modules/ROOT/pages/try-it-out-locally.adoc
+++ b/docs/modules/ROOT/pages/try-it-out-locally.adoc
@@ -43,13 +43,13 @@ and add a property at the end
 [source,bash]
 ----
 # Set to a list of filesystem paths separated by commas (,) to enable class loading isolation for plugins
-# (connectors, converters, transformations). The list should consist of top level directories that include 
-# any combination of: 
+# (connectors, converters, transformations). The list should consist of top level directories that include
+# any combination of:
 # a) directories immediately containing jars with plugins and their dependencies
 # b) uber-jars with plugins and their dependencies
 # c) directories immediately containing the package directory structure of classes of plugins and their dependencies
 # Note: symlinks will be followed to discover dependencies or plugins.
-# Examples: 
+# Examples:
 # plugin.path=/usr/local/share/java,/usr/local/share/kafka/plugins,/opt/connectors,
 plugin.path=/home/connectors
 ----
@@ -285,7 +285,7 @@ docker inspect --format='{{ .NetworkSettings.IPAddress }}' master_node
 [[Tryitoutlocally-CassandraQLSource]]
 ==== Apache Cassandra (source)
 
-This example polls Cassandra via CSQL (`select * from users`) in the `test` keyspace and transfers the result to the `mytopic` Kafka topic. 
+This example polls Cassandra via CSQL (`select * from users`) in the `test` keyspace and transfers the result to the `mytopic` Kafka topic.
 
 .Run the Cassandra CQL source:
 [source,bash]
@@ -388,7 +388,7 @@ First thing to do, is unzip or untar the camel-aws-sqs-kafka-connector archive i
 > unzip camel-http-kafka-connector-0.6.0-SNAPSHOT-package.zip
 ----
 
-This example sends data from `mytopic` Kafka topic to a HTTP service. Adjust properties in `docs/examples/CamelHttpSinkConnector.properties` for your environment, for example configuring the `camel.sink.url`. 
+This example sends data from `mytopic` Kafka topic to a HTTP service. Adjust properties in `docs/examples/CamelHttpSinkConnector.properties` for your environment, for example configuring the `camel.sink.url`.
 
 .Run the http sink:
 [source,bash]
@@ -408,7 +408,7 @@ First thing to do, is unzip or untar the camel-aws-sqs-kafka-connector archive i
 > unzip camel-sjsm2-kafka-connector-0.6.0-SNAPSHOT-package.zip
 ----
 
-These are the basic connectors. For camel-sjms2 we have a bunch of provided dependencies we need to add in our path, so run the following commands:
+These are the basic connectors. For camel-sjms2 we have a bunch of provided dependencies we need to add in our path, so run the following commands (note that this is not needed from 0.7.0 onward for ActiveMQ and Artemis JMS clients, as their dependecies are packaged along with the SJMS2 connector):
 
 [source,bash]
 ----
@@ -418,7 +418,8 @@ These are the basic connectors. For camel-sjms2 we have a bunch of provided depe
 > wget https://repo1.maven.org/maven2/org/apache/geronimo/specs/geronimo-annotation_1.0_spec/1.1.1/geronimo-annotation_1.0_spec-1.1.1.jar
 > wget https://repo1.maven.org/maven2/javax/management/j2ee/management-api/1.1-rev-1/management-api-1.1-rev-1.jar
 > wget https://repo1.maven.org/maven2/org/fusesource/hawtbuf/hawtbuf/1.11/hawtbuf-1.11.jar
-```
+----
+
 
 This example receives messages from a JMS queue named `myqueue` and transfers them to `mytopic` Kafka topic. In this example ActiveMQ is used and it's configured to connect to the broker running on `localhost:61616`. Adjust properties in `examples/CamelJmsSourceConnector.properties` for your environment, for example configuring username and password by setting `camel.component.sjms2.connection-factory.userName=yourusername` and `camel.component.sjms2.connection-factory.password=yourpassword` or change the `camel.component.sjms2.connection-factory` and `camel.component.sjms2.connection-factory.brokerURL` to reflect your JMS implementation and URL.
 

--- a/tooling/camel-kafka-connector-generator-maven-plugin/src/main/resources/camel-kafka-connector-fix-dependencies.properties
+++ b/tooling/camel-kafka-connector-generator-maven-plugin/src/main/resources/camel-kafka-connector-fix-dependencies.properties
@@ -22,6 +22,6 @@
 global=org.apache.camel.kafkaconnector:camel-kafka-connector
 
 # we add a default connection factory maven variables can be used as ${varname}
-camel-sjms2=org.apache.activemq:activemq-client,org.apache.activemq:artemis-jms-client
+camel-sjms2=org.apache.activemq:activemq-client::runtime,org.apache.activemq:artemis-jms-client::runtime
 exclude_camel-sjms2=
 additional_properties_camel-sjms2=camel.component.sjms2.connection-factory=#class:org.apache.activemq.ActiveMQConnectionFactory,camel.component.sjms2.connection-factory.brokerURL=tcp://localhost:61616


### PR DESCRIPTION
Not sure if there is a better way to do this, but it works and it is much more convenient. What do you think?