### PR TITLE
Support camel dataformat configuration for marshaller/unmarshaller #816

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -83,6 +83,11 @@
         <!-- Test -->
         <dependency>
             <groupId>org.apache.camel</groupId>
+            <artifactId>camel-fhir</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
             <artifactId>camel-hl7</artifactId>
             <scope>test</scope>
         </dependency>

--- a/core/src/main/java/org/apache/camel/kafkaconnector/utils/CamelKafkaConnectDataformat.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/utils/CamelKafkaConnectDataformat.java
@@ -16,6 +16,51 @@
  */
 package org.apache.camel.kafkaconnector.utils;
 
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.model.DataFormatDefinition;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.camel.model.dataformat.ASN1DataFormat;
+import org.apache.camel.model.dataformat.Any23DataFormat;
+import org.apache.camel.model.dataformat.AvroDataFormat;
+import org.apache.camel.model.dataformat.Base64DataFormat;
+import org.apache.camel.model.dataformat.BeanioDataFormat;
+import org.apache.camel.model.dataformat.BindyDataFormat;
+import org.apache.camel.model.dataformat.CBORDataFormat;
+import org.apache.camel.model.dataformat.CsvDataFormat;
+import org.apache.camel.model.dataformat.FhirJsonDataFormat;
+import org.apache.camel.model.dataformat.FhirXmlDataFormat;
+import org.apache.camel.model.dataformat.GrokDataFormat;
+import org.apache.camel.model.dataformat.GzipDataFormat;
+import org.apache.camel.model.dataformat.HL7DataFormat;
+import org.apache.camel.model.dataformat.IcalDataFormat;
+import org.apache.camel.model.dataformat.JacksonXMLDataFormat;
+import org.apache.camel.model.dataformat.JaxbDataFormat;
+import org.apache.camel.model.dataformat.JsonApiDataFormat;
+import org.apache.camel.model.dataformat.JsonDataFormat;
+import org.apache.camel.model.dataformat.LZFDataFormat;
+import org.apache.camel.model.dataformat.MimeMultipartDataFormat;
+import org.apache.camel.model.dataformat.PGPDataFormat;
+import org.apache.camel.model.dataformat.ProtobufDataFormat;
+import org.apache.camel.model.dataformat.RssDataFormat;
+import org.apache.camel.model.dataformat.SoapJaxbDataFormat;
+import org.apache.camel.model.dataformat.SyslogDataFormat;
+import org.apache.camel.model.dataformat.TarFileDataFormat;
+import org.apache.camel.model.dataformat.ThriftDataFormat;
+import org.apache.camel.model.dataformat.TidyMarkupDataFormat;
+import org.apache.camel.model.dataformat.XMLSecurityDataFormat;
+import org.apache.camel.model.dataformat.XStreamDataFormat;
+import org.apache.camel.model.dataformat.YAMLDataFormat;
+import org.apache.camel.model.dataformat.ZipDeflaterDataFormat;
+import org.apache.camel.support.PropertyBindingSupport;
+
+
+
+
 public class CamelKafkaConnectDataformat {
     private final String dataformatId;
     private final CamelKafkaConnectDataformatKind dataformatKind;
@@ -35,6 +80,147 @@ public class CamelKafkaConnectDataformat {
 
     public enum CamelKafkaConnectDataformatKind {
         MARSHALL,
-        UNMARSHALL
+        UNMARSHALL;
+    }
+
+    public static void configureMarshalDataformat(RouteDefinition rd, CamelContext context, String dataFormatName, Properties camelProperties) {
+        Predicate<String> keyFilter = key -> key.contains(".marshal." + dataFormatName + ".");
+        DataFormatDefinition dfd = configureDataformat(context, dataFormatName, keyFilter, camelProperties);
+        if (dfd != null) {
+            rd.marshal(dfd);
+        } else {
+            rd.marshal(dataFormatName);
+        }
+    }
+
+
+    public static void configureUnmarshalDataformat(RouteDefinition rd, CamelContext context, String dataFormatName, Properties camelProperties) {
+        Predicate<String> keyFilter = key -> key.contains(".unmarshal." + dataFormatName + ".");
+        DataFormatDefinition dfd = configureDataformat(context, dataFormatName, keyFilter, camelProperties);
+        if (dfd != null) {
+            rd.unmarshal(dfd);
+        } else {
+            rd.unmarshal(dataFormatName);
+        }
+    }
+
+    public static DataFormatDefinition configureDataformat(CamelContext context, String dataFormatName, Predicate<String> keyFilter, Properties camelProperties) {
+        Map<String, Object> dataFormatProps = camelProperties.stringPropertyNames()
+                .stream()
+                .filter(keyFilter)
+                .collect(Collectors.toMap(key -> key.substring(key.lastIndexOf(".") + 1), key -> camelProperties.get(key)));
+
+        DataFormatDefinition dataformat;
+
+        switch (dataFormatName) {
+            case "any23":
+                dataformat = new Any23DataFormat();
+                break;
+            case "avro":
+                dataformat = new AvroDataFormat();
+                break;
+            case "base64":
+                dataformat = new Base64DataFormat();
+                break;
+            case "beanio":
+                dataformat = new BeanioDataFormat();
+                break;
+            case "bindy":
+                dataformat = new BindyDataFormat();
+                break;
+            case "cbor":
+                dataformat = new CBORDataFormat();
+                break;
+            case "csv":
+                dataformat = new CsvDataFormat();
+                break;
+            case "csvLazyLoad":
+                dataformat = new CsvDataFormat(true);
+                break;
+            case "grok":
+                dataformat = new GrokDataFormat();
+                break;
+            case "gzipDeflater":
+                dataformat = new GzipDataFormat();
+                break;
+            case "hl7":
+                dataformat = new HL7DataFormat();
+                break;
+            case "ical":
+                dataformat = new IcalDataFormat();
+                break;
+            case "lzf":
+                dataformat = new LZFDataFormat();
+                break;
+            case "mimeMultipart":
+                dataformat = new MimeMultipartDataFormat();
+                break;
+            case "pgp":
+                dataformat = new PGPDataFormat();
+                break;
+            case "jacksonxml":
+                dataformat = new JacksonXMLDataFormat();
+                break;
+            case "jaxb":
+                dataformat = new JaxbDataFormat();
+                break;
+            case "json":
+                dataformat = new JsonDataFormat();
+                break;
+            case "jsonApi":
+                dataformat = new JsonApiDataFormat();
+                break;
+            case "protobuf":
+                dataformat = new ProtobufDataFormat();
+                break;
+            case "rss":
+                dataformat = new RssDataFormat();
+                break;
+            case "soapjaxb":
+                dataformat = new SoapJaxbDataFormat();
+                break;
+            case "soapjaxb12":
+                SoapJaxbDataFormat soap = new SoapJaxbDataFormat();
+                soap.setVersion("1.2");
+                dataformat = soap;
+                break;
+            case "syslog":
+                dataformat = new SyslogDataFormat();
+                break;
+            case "thrift":
+                dataformat = new ThriftDataFormat();
+                break;
+            case "tidyMarkup":
+                dataformat = new TidyMarkupDataFormat();
+                break;
+            case "xstream":
+                dataformat = new XStreamDataFormat();
+                break;
+            case "yaml":
+                dataformat = new YAMLDataFormat();
+                break;
+            case "secureXML":
+                dataformat = new XMLSecurityDataFormat();
+                break;
+            case "tarFile":
+                dataformat = new TarFileDataFormat();
+                break;
+            case "zipDeflater":
+                dataformat = new ZipDeflaterDataFormat();
+                break;
+            case "asn1":
+                dataformat = new ASN1DataFormat();
+                break;
+            case "fhirJson":
+                dataformat = new FhirJsonDataFormat();
+                break;
+            case "fhirXml":
+                dataformat = new FhirXmlDataFormat();
+                break;
+            default:
+                return null;
+        }
+        PropertyBindingSupport.bindProperties(context, dataformat, dataFormatProps);
+        return dataformat;
     }
 }

--- a/core/src/main/java/org/apache/camel/kafkaconnector/utils/CamelKafkaConnectMain.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/utils/CamelKafkaConnectMain.java
@@ -252,11 +252,13 @@ public class CamelKafkaConnectMain extends SimpleMain {
                     //dataformats
                     if (!ObjectHelper.isEmpty(marshallDataFormat)) {
                         LOG.info(".marshal({})", marshallDataFormat);
-                        rd.marshal(marshallDataFormat);
+                        CamelKafkaConnectDataformat.configureMarshalDataformat(rd, camelMain.getCamelContext(), marshallDataFormat, camelProperties);
+                        //rd.marshal(marshallDataFormat).marshal();
                     }
                     if (!ObjectHelper.isEmpty(unmarshallDataFormat)) {
                         LOG.info(".unmarshal({})", unmarshallDataFormat);
-                        rd.unmarshal(unmarshallDataFormat);
+                        CamelKafkaConnectDataformat.configureUnmarshalDataformat(rd, camelMain.getCamelContext(), unmarshallDataFormat, camelProperties);
+
                     }
                     if (getContext().getRegistry().lookupByName("aggregate") != null) {
                         //aggregation

--- a/core/src/test/java/org/apache/camel/kafkaconnector/DataFormatTest.java
+++ b/core/src/test/java/org/apache/camel/kafkaconnector/DataFormatTest.java
@@ -60,6 +60,34 @@ public class DataFormatTest {
     }
 
     @Test
+    public void testDataFormatFhirJsonSink() {
+        Map<String, String> props = new HashMap<>();
+        props.put("camel.sink.url", "direct://test");
+        props.put("camel.sink.kafka.topic", "mytopic");
+     //   props.put("camel.sink.unmarshal", "syslog");
+        props.put("camel.sink.marshal", "fhirJson");
+        props.put("camel.sink.marshal.fhirJson.fhirVersion", "R4");
+        props.put("camel.sink.marshal.fhirJson.prettyPrint", "true");
+        CamelSinkTask camelsinkTask = new CamelSinkTask();
+        camelsinkTask.start(props);
+        camelsinkTask.stop();
+    }
+
+    @Test
+    public void testUnmarshalDataFormatFhirJsonSource() {
+        Map<String, String> props = new HashMap<>();
+        props.put("camel.source.url", "direct://test");
+        props.put("camel.source.kafka.topic", "mytopic");
+        props.put("camel.source.unmarshal", "fhirJson");
+        props.put("camel.source.unmarshal.fhirJson.fhirVersion", "R4");
+        props.put("camel.source.unmarshal.fhirJson.prettyPrint", "true");
+        CamelSourceTask camelsourceTask = new CamelSourceTask();
+        camelsourceTask.start(props);
+        camelsourceTask.stop();
+    }
+
+
+    @Test
     public void testDataFormatNotFound() {
         Map<String, String> props = new HashMap<>();
         props.put("camel.sink.url", "direct://test");
@@ -76,27 +104,27 @@ public class DataFormatTest {
         Map<String, String> props = new HashMap<>();
         props.put("camel.source.url", "direct://test");
         props.put("topics", "mytopic");
-        props.put("camel.source.marshal", "hl7");
-        props.put("camel.source.unmarshal", "syslog");
+        props.put("camel.source.marshal", "myHl7");
+        props.put("camel.source.unmarshal", "mySyslog");
         DefaultCamelContext dcc = new DefaultCamelContext();
 
         CamelKafkaConnectMain cms = CamelKafkaConnectMain.builder("direct://start", "log://test")
             .withProperties(props)
-            .withUnmarshallDataFormat("syslog")
-            .withMarshallDataFormat("hl7")
+            .withUnmarshallDataFormat("mySyslog")
+            .withMarshallDataFormat("myHl7")
             .build(dcc);
 
         HL7DataFormat hl7Df = new HL7DataFormat();
         hl7Df.setValidate(false);
-        dcc.getRegistry().bind("hl7", hl7Df);
+        dcc.getRegistry().bind("myHl7", hl7Df);
 
         SyslogDataFormat syslogDf = new SyslogDataFormat();
-        dcc.getRegistry().bind("syslog", syslogDf);
+        dcc.getRegistry().bind("mySyslog", syslogDf);
 
         cms.start();
-        HL7DataFormat hl7dfLoaded = (HL7DataFormat)dcc.resolveDataFormat("hl7");
+        HL7DataFormat hl7dfLoaded = (HL7DataFormat)dcc.resolveDataFormat("myHl7");
         assertNotNull(hl7dfLoaded);
-        SyslogDataFormat syslogDfLoaded = (SyslogDataFormat)dcc.resolveDataFormat("syslog");
+        SyslogDataFormat syslogDfLoaded = (SyslogDataFormat)dcc.resolveDataFormat("mySyslog");
         assertNotNull(syslogDfLoaded);
         cms.stop();
     }
@@ -106,20 +134,20 @@ public class DataFormatTest {
         Map<String, String> props = new HashMap<>();
         props.put("camel.source.url", "direct://test");
         props.put("topics", "mytopic");
-        props.put("camel.source.marshal", "hl7");
+        props.put("camel.source.marshal", "myHl7");
 
         DefaultCamelContext dcc = new DefaultCamelContext();
         CamelKafkaConnectMain cms = CamelKafkaConnectMain.builder("direct://start", "log://test")
             .withProperties(props)
-            .withMarshallDataFormat("hl7")
+            .withMarshallDataFormat("myHl7")
             .build(dcc);
 
         HL7DataFormat hl7df = new HL7DataFormat();
         hl7df.setValidate(false);
-        dcc.getRegistry().bind("hl7", hl7df);
+        dcc.getRegistry().bind("myHl7", hl7df);
 
         cms.start();
-        HL7DataFormat hl7dfLoaded = (HL7DataFormat)dcc.resolveDataFormat("hl7");
+        HL7DataFormat hl7dfLoaded = (HL7DataFormat)dcc.resolveDataFormat("myHl7");
         assertFalse(hl7dfLoaded.isValidate());
         cms.stop();
     }


### PR DESCRIPTION
this pr allow the configuration of a dataformat directly in properties file, something like:


```
camel.source.unmarshal=fhirJson
camel.source.unmarshal.fhirJson.fhirVersion=R4
camel.source.unmarshal.fhirJson.prettyPrint=true
```