### PR TITLE
Camel-Cron connector: We need to add at least camel-quartz as dependency

### DIFF
--- a/connectors/camel-cron-kafka-connector/pom.xml
+++ b/connectors/camel-cron-kafka-connector/pom.xml
@@ -44,6 +44,10 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-cron</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-quartz</artifactId>
+    </dependency>
     <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel.kafkaconnector</groupId>


### PR DESCRIPTION
Fixes #908 