### PR TITLE
Fix problem when call 'context.errantRecordReporter()' will result in a NoSuchMethodException or NoClassDefFoundError when the sink connector is deployed to Connect runtimes older than Kafka 2.6

### DIFF
--- a/core/src/main/java/org/apache/camel/kafkaconnector/CamelSinkTask.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/CamelSinkTask.java
@@ -75,7 +75,12 @@ public class CamelSinkTask extends SinkTask {
             CamelSinkConnectorConfig config = getCamelSinkConnectorConfig(actualProps);
 
             if (context != null) {
-                reporter = context.errantRecordReporter();
+                try {
+                    reporter = context.errantRecordReporter();
+                } catch (NoSuchMethodError | NoClassDefFoundError e) {
+                    LOG.warn("Unable to instantiate ErrantRecordReporter.  Method 'SinkTaskContext.errantRecordReporter' does not exist.");
+                    reporter = null;
+                }
             }
 
             try {


### PR DESCRIPTION
According to the documentation https://kafka.apache.org/26/javadoc/org/apache/kafka/connect/sink/SinkTaskContext.html#errantRecordReporter--
changes must be made to ensure backward compatibility.

Excerpt from the documentation:

This method was added in Apache Kafka 2.6. Sink tasks that use this method but want to maintain backward compatibility so they can also be deployed to older 
Connect runtimes should guard the call to this method with a try-catch block, since calling this method will result in a NoSuchMethodException or NoClassDefFoundError 
when the sink connector is deployed to Connect runtimes older than Kafka 2.6. For example:


     try {
         reporter = context.errantRecordReporter();
     } catch (NoSuchMethodError | NoClassDefFoundError e) {
         reporter = null;
     }`