### PR TITLE
Ensure parallel builds with mvnd work on clean environments

### DIFF
--- a/archetypes/camel-kafka-connector-extensible-archetype/pom.xml
+++ b/archetypes/camel-kafka-connector-extensible-archetype/pom.xml
@@ -32,6 +32,15 @@
     <name>Camel Kafka Connector :: Archetypes :: Camel Kafka connector extensible</name>
     <packaging>maven-archetype</packaging>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.kafkaconnector</groupId>
+            <artifactId>camel-timer-kafka-connector</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <extensions>
             <extension>


### PR DESCRIPTION
The camel-timer-kafka-connector is a dependency for the camel-kafka-connector-extensible-archetype module. Adding it to guarantee we correctly list test dependencies and also ensure parallel builds by tools such as mvnd work out of the box.