### PR TITLE
Add tests to camel-kafka-connector-generator-maven-plugin

### DIFF
--- a/buildingtools/src/main/resources/camel-checkstyle-suppressions.xml
+++ b/buildingtools/src/main/resources/camel-checkstyle-suppressions.xml
@@ -78,4 +78,10 @@
     <suppress checks="LineLength"
               files=".*/resources/.*request.xml"
               />
+    <suppress checks="MethodName"
+              files=".*/tooling/.+-maven-plugin/src/test/java[\\\/].+IT\.java"
+              />
+    <suppress checks=".*"
+              files=".*/tooling/.+-maven-plugin/src/test/resources/template-connector-package.xml"
+              />
 </suppressions>

--- a/tooling/camel-kafka-connector-generator-maven-plugin/README.adoc
+++ b/tooling/camel-kafka-connector-generator-maven-plugin/README.adoc
@@ -24,3 +24,16 @@ The Camel Kafka Connector generator plugin allows you to generator connectors ba
 | packageFileTemplate | camel-kafka-connector-template-package.template | Package file template to be placed in src/main/assembly/package.xml
 | exampleSinkPropertiesFileTemplate | camel-kafka-connector-template-example-sink-properties.template | Example connector sink file template
 |===============
+
+=== Developers
+
+==== Run Maven plugin integration tests
+
+The link:src/test/java/org/apache/camel/kafkaconnector/maven[Maven IT tests] try to generate all CKC connectors from Camel catalog for testing under `target/`. It's costly and time consuming, so disabled by default.
+
+To run the IT tests manually:
+
+[source,bash]
+----
+mvn clean verify -Pmaven-it
+----

--- a/tooling/camel-kafka-connector-generator-maven-plugin/pom.xml
+++ b/tooling/camel-kafka-connector-generator-maven-plugin/pom.xml
@@ -191,6 +191,19 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.soebes.itf.jupiter.extension</groupId>
+            <artifactId>itf-jupiter-extension</artifactId>
+            <version>${itf-jupiter-extension-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.soebes.itf.jupiter.extension</groupId>
+            <artifactId>itf-assertj</artifactId>
+            <version>${itf-jupiter-extension-version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -208,5 +221,73 @@
                 <filtering>false</filtering>
             </resource>
         </resources>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>false</filtering>
+            </testResource>
+            <testResource>
+                <directory>src/test/resources-its</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <configuration>
+                    <!-- escape string is used for filtered IT resources -->
+                    <escapeString>\</escapeString>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>maven-it</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.soebes.itf.jupiter.extension</groupId>
+                        <artifactId>itf-maven-plugin</artifactId>
+                        <version>${itf-jupiter-extension-version}</version>
+                        <executions>
+                            <execution>
+                                <id>installing</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>install</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <maven.version>${maven.version}</maven.version>
+                                <maven.home>${maven.home}</maven.home>
+                            </systemProperties>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test</id>
+                                <!-- maven-it-extension must run in integration-test phase -->
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/tooling/camel-kafka-connector-generator-maven-plugin/src/main/java/org/apache/camel/kafkaconnector/maven/AbstractCamelKafkaConnectorMojo.java
+++ b/tooling/camel-kafka-connector-generator-maven-plugin/src/main/java/org/apache/camel/kafkaconnector/maven/AbstractCamelKafkaConnectorMojo.java
@@ -138,7 +138,7 @@ public abstract class AbstractCamelKafkaConnectorMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         configureResourceManager();
         if (!project.getArtifactId().equals(connectorsProjectName)) {
-            getLog().debug("Skipping project " + project.getArtifactId() + " since it is not " + connectorsProjectName + " can be configured with <connectors-project-name> option.");
+            getLog().debug("Skipping project " + project.getArtifactId() + " since it is not " + connectorsProjectName + ", which can be configured with <connectorsProjectName> option.");
             return;
         }
         try {

--- a/tooling/camel-kafka-connector-generator-maven-plugin/src/main/java/org/apache/camel/kafkaconnector/maven/GenerateCamelKafkaConnectorsMojo.java
+++ b/tooling/camel-kafka-connector-generator-maven-plugin/src/main/java/org/apache/camel/kafkaconnector/maven/GenerateCamelKafkaConnectorsMojo.java
@@ -16,7 +16,8 @@
  */
 package org.apache.camel.kafkaconnector.maven;
 
-import java.io.*;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -44,7 +45,6 @@ import org.apache.maven.project.ProjectBuilder;
 import org.codehaus.plexus.resource.loader.FileResourceCreationException;
 import org.codehaus.plexus.resource.loader.ResourceNotFoundException;
 
-import static org.apache.camel.kafkaconnector.maven.utils.MavenUtils.sanitizeMavenArtifactId;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.artifactId;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.configuration;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.element;
@@ -153,7 +153,8 @@ public class GenerateCamelKafkaConnectorsMojo extends AbstractCamelKafkaConnecto
                             element(name("licenseTemplate"), licenseTemplate),
                             element(name("fixDependenciesProperties"), fixDependenciesProperties),
                             element(name("packageFileTemplate"), packageFileTemplate),
-                            element(name("overridePomFile"), overridePomFile.toString())
+                            element(name("overridePomFile"), overridePomFile.toString()),
+                            element(name("connectorsProjectName"), connectorsProjectName)
                     ),
                     executionEnvironment(
                             project,
@@ -177,7 +178,8 @@ public class GenerateCamelKafkaConnectorsMojo extends AbstractCamelKafkaConnecto
                             element(name("noticeTemplate"), noticeTemplate),
                             element(name("licenseTemplate"), licenseTemplate),
                             element(name("fixDependenciesProperties"), fixDependenciesProperties),
-                            element(name("packageFileTemplate"), packageFileTemplate)
+                            element(name("packageFileTemplate"), packageFileTemplate),
+                            element(name("connectorsProjectName"), connectorsProjectName)
                     ),
                     executionEnvironment(
                             project,
@@ -211,7 +213,8 @@ public class GenerateCamelKafkaConnectorsMojo extends AbstractCamelKafkaConnecto
                                 ),
                                 goal("camel-kafka-connector-delete"),
                                 configuration(
-                                        element(name("name"), component)
+                                        element(name("name"), component),
+                                        element(name("connectorsProjectName"), connectorsProjectName)
                                 ),
                                 executionEnvironment(
                                         project,

--- a/tooling/camel-kafka-connector-generator-maven-plugin/src/test/java/org/apache/camel/kafkaconnector/maven/GenerateCamelKafkaConnectorsMojoIT.java
+++ b/tooling/camel-kafka-connector-generator-maven-plugin/src/test/java/org/apache/camel/kafkaconnector/maven/GenerateCamelKafkaConnectorsMojoIT.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.kafkaconnector.maven;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.soebes.itf.jupiter.extension.MavenJupiterExtension;
+import com.soebes.itf.jupiter.extension.MavenRepository;
+import com.soebes.itf.jupiter.extension.MavenTest;
+import com.soebes.itf.jupiter.maven.MavenExecutionResult;
+import org.apache.camel.kafkaconnector.maven.utils.MavenUtils;
+import org.apache.camel.tooling.util.Strings;
+
+import static com.soebes.itf.extension.assertj.MavenExecutionResultAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@MavenJupiterExtension
+@MavenRepository
+class GenerateCamelKafkaConnectorsMojoIT {
+
+    @MavenTest
+    public void test_generate(MavenExecutionResult result) throws IOException {
+        assertThat(result).isSuccessful();
+        assertThat(result)
+            .out()
+            .info()
+            .contains("Excluded Components that won't be generated: "
+                + "[bonita,"
+                + " bean-validator,"
+                + " browse,"
+                + " class,"
+                + " dataset,"
+                + " dataset-test,"
+                + " debezium-mongodb,"
+                + " debezium-mysql,"
+                + " debezium-postgres,"
+                + " debezium-sqlserver,"
+                + " digitalocean,"
+                + " mock,"
+                + " ref,"
+                + " robotframework"
+                + "]")
+            .anyMatch(s -> s.startsWith("Components found to be generated/updated: ["))
+            .anyMatch(s -> s.startsWith("Creating camel kafka connector for"))
+            .containsSequence(
+                "Creating a new pom.xml for the connector from scratch",
+                "Creating a new package.xml for the connector.")
+            .anyMatch(s -> s.startsWith("Updated doc file:"));
+
+        List<String> stdout = Files.readAllLines(result.getMavenLog().getStdout());
+        List<String> generated = extractGenerated(stdout);
+        List<String> excluded = extractExcluded(stdout);
+
+        // verify component directories are really generated
+        generated.stream()
+            .map(MavenUtils::sanitizeMavenArtifactId)
+            .map(m -> "camel-" + m + "-kafka-connector")
+            .forEach(m -> assertThat(result).project().hasModule(m));
+
+        // verify excluded components are not generated
+        Set<String> files = Arrays.stream(Objects.requireNonNull(result.getMavenProjectResult().getBaseDir().listFiles()))
+            .map(File::getName)
+            .collect(Collectors.toCollection(HashSet::new));
+        excluded.stream()
+            .map(MavenUtils::sanitizeMavenArtifactId)
+            .map(m -> "camel-" + m + "-kafka-connector")
+            .forEach(m -> assertFalse(files.contains(m), "component should be excluded"));
+    }
+
+    private List<String> extractExcluded(List<String> stdout) {
+        return stdout.stream()
+            .filter(s -> s.startsWith("[INFO] Excluded Components that won't be generated: ["))
+            .findFirst()
+            .map(s -> Strings.between(s, "[INFO] Excluded Components that won't be generated: [", "]"))
+            .map(s -> Arrays.asList(s.split(", ")))
+            .orElse(Collections.emptyList());
+    }
+
+    private List<String> extractGenerated(List<String> stdout) {
+        return stdout.stream()
+            .filter(s -> s.startsWith("[INFO] Components found to be generated/updated: ["))
+            .findFirst()
+            .map(s -> Strings.between(s, "[INFO] Components found to be generated/updated: [", "]"))
+            .map(s -> Arrays.asList(s.split(", ")))
+            .orElse(Collections.emptyList());
+    }
+}

--- a/tooling/camel-kafka-connector-generator-maven-plugin/src/test/resources-its/org/apache/camel/kafkaconnector/maven/GenerateCamelKafkaConnectorsMojoIT/test_generate/pom.xml
+++ b/tooling/camel-kafka-connector-generator-maven-plugin/src/test/resources-its/org/apache/camel/kafkaconnector/maven/GenerateCamelKafkaConnectorsMojoIT/test_generate/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.camel.kafkaconnector.test</groupId>
+    <artifactId>test-project</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Test Project</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.camel.kafkaconnector</groupId>
+                <artifactId>camel-kafka-connector-generator-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <connectorsProjectName>\${project.artifactId}</connectorsProjectName>
+                    <!-- set to true to make build fail fast if missing documentation in docs files -->
+                    <!--  <failFast>false</failFast> -->
+                    <!-- set to true to make build fail if an option has no description -->
+                    <!--  <failOnMissingDescription>false</failOnMissingDescription> -->
+                    <!-- Process just this, comma separated, components -->
+                    <!--  <filter></filter>-->
+                    <!-- Regenerate connector pom file completely even if one already exists -->
+                    <!-- WARNING: you may lose some changes done to the pom. -->
+                    <!-- <overridePomFile>false</overridePomFile> -->
+                    <initialPomTemplate>
+                        ${project.build.testOutputDirectory}/template-connector-pom.xml
+                    </initialPomTemplate>
+                    <noticeTemplate>
+                        ${project.build.testOutputDirectory}/camel-kafka-connector-NOTICE.txt
+                    </noticeTemplate>
+                    <licenseTemplate>
+                        ${project.build.testOutputDirectory}/camel-kafka-connector-LICENSE.txt
+                    </licenseTemplate>
+                    <fixDependenciesProperties>
+                        ${project.build.testOutputDirectory}/camel-kafka-connector-fix-dependencies.properties
+                    </fixDependenciesProperties>
+                    <packageFileTemplate>
+                        ${project.build.testOutputDirectory}/template-connector-package.xml
+                    </packageFileTemplate>
+                    <exampleSourcePropertiesFileTemplate>
+                        ${project.build.testOutputDirectory}/camel-kafka-connector-template-example-source-properties.template
+                    </exampleSourcePropertiesFileTemplate>
+                    <exampleSinkPropertiesFileTemplate>
+                        ${project.build.testOutputDirectory}/camel-kafka-connector-template-example-sink-properties.template
+                    </exampleSinkPropertiesFileTemplate>
+                    <excludedComponents>
+                        <param>bonita</param>
+                        <param>bean-validator</param>
+                        <param>browse</param>
+                        <param>class</param>
+                        <param>dataset</param>
+                        <param>dataset-test</param>
+                        <param>debezium-mongodb</param>
+                        <param>debezium-mysql</param>
+                        <param>debezium-postgres</param>
+                        <param>debezium-sqlserver</param>
+                        <param>digitalocean</param>
+                        <param>mock</param>
+                        <param>ref</param>
+                        <param>robotframework</param>
+                    </excludedComponents>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>test_generate</id>
+                        <goals>
+                            <goal>generate-camel-kafka-connectors</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.camel</groupId>
+                        <artifactId>camel-catalog</artifactId>
+                        <version>@camel.version@</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+    <modules>
+    </modules>
+</project>

--- a/tooling/camel-kafka-connector-generator-maven-plugin/src/test/resources/camel-kafka-connector-LICENSE.txt
+++ b/tooling/camel-kafka-connector-generator-maven-plugin/src/test/resources/camel-kafka-connector-LICENSE.txt
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/tooling/camel-kafka-connector-generator-maven-plugin/src/test/resources/camel-kafka-connector-NOTICE.txt
+++ b/tooling/camel-kafka-connector-generator-maven-plugin/src/test/resources/camel-kafka-connector-NOTICE.txt
@@ -1,0 +1,11 @@
+   =========================================================================
+   ==  NOTICE file corresponding to the section 4 d of                    ==
+   ==  the Apache License, Version 2.0,                                   ==
+   ==  in this case for the Apache Camel distribution.                    ==
+   =========================================================================
+
+   This product includes software developed by
+   The Apache Software Foundation (http://www.apache.org/).
+
+   Please read the different LICENSE files present in the licenses directory of
+   this distribution.

--- a/tooling/camel-kafka-connector-generator-maven-plugin/src/test/resources/camel-kafka-connector-fix-dependencies.properties
+++ b/tooling/camel-kafka-connector-generator-maven-plugin/src/test/resources/camel-kafka-connector-fix-dependencies.properties
@@ -1,0 +1,27 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+# This file contains additional dependencies needed by camel components packaged as kafka connectors
+# Use comma-separated values to include multiple dependencies
+
+# Global dependencies included in all modules (except the ones in the list)
+global=org.apache.camel.kafkaconnector:camel-kafka-connector,org.apache.camel:camel-jackson
+
+# we add a default connection factory maven variables can be used as ${varname}
+camel-sjms2=org.apache.activemq:activemq-client::runtime,org.apache.activemq:artemis-jms-client::runtime
+exclude_camel-sjms2=
+additional_properties_camel-sjms2=camel.component.sjms2.connection-factory=#class:org.apache.activemq.ActiveMQConnectionFactory,camel.component.sjms2.connection-factory.brokerURL=tcp://localhost:61616

--- a/tooling/camel-kafka-connector-generator-maven-plugin/src/test/resources/camel-kafka-connector-java-header.txt
+++ b/tooling/camel-kafka-connector-generator-maven-plugin/src/test/resources/camel-kafka-connector-java-header.txt
@@ -1,0 +1,16 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/tooling/camel-kafka-connector-generator-maven-plugin/src/test/resources/camel-kafka-connector-template-example-sink-properties.template
+++ b/tooling/camel-kafka-connector-generator-maven-plugin/src/test/resources/camel-kafka-connector-template-example-sink-properties.template
@@ -1,0 +1,33 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+name=Camel@{connectorName}SinkConnector
+connector.class=@{connectorClass}
+tasks.max=1
+
+# use the kafka converters that better suit your needs, these are just defaults:
+key.converter=org.apache.kafka.connect.storage.StringConverter
+value.converter=org.apache.kafka.connect.storage.StringConverter
+
+# comma separated topics to get messages from
+topics=
+
+# mandatory properties (for a complete properties list see the connector documentation):
+
+@foreach{opt : options}# @{opt.description}
+@{opt.name}=
+@end{}

--- a/tooling/camel-kafka-connector-generator-maven-plugin/src/test/resources/camel-kafka-connector-template-example-source-properties.template
+++ b/tooling/camel-kafka-connector-generator-maven-plugin/src/test/resources/camel-kafka-connector-template-example-source-properties.template
@@ -1,0 +1,33 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+name=Camel@{connectorName}SourceConnector
+connector.class=@{connectorClass}
+tasks.max=1
+
+# use the kafka converters that better suit your needs, these are just defaults:
+key.converter=org.apache.kafka.connect.storage.StringConverter
+value.converter=org.apache.kafka.connect.storage.StringConverter
+
+# comma separated topics to send messages into
+topics=
+
+# mandatory properties (for a complete properties list see the connector documentation):
+
+@foreach{opt : options}# @{opt.description}
+@{opt.name}=
+@end{}

--- a/tooling/camel-kafka-connector-generator-maven-plugin/src/test/resources/template-connector-package.xml
+++ b/tooling/camel-kafka-connector-generator-maven-plugin/src/test/resources/template-connector-package.xml
@@ -1,0 +1,58 @@
+<#ftl output_format="XML" strip_whitespace=false>
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly>
+  <!-- Assembles a packaged version targeting OS installation. -->
+  <id>package</id>
+  <formats>
+    <format>zip</format>
+    <format>tar.gz</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory><#noparse>${project.basedir}/../..</#noparse></directory>
+      <outputDirectory><#noparse>${project.artifactId}/</#noparse></outputDirectory>
+      <includes>
+        <include>README*</include>
+        <include>LICENSE*</include>
+        <include>NOTICE*</include>
+        <include>licenses/</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory><#noparse>${project.basedir}/src/main/docs</#noparse></directory>
+      <outputDirectory><#noparse>docs/</#noparse></outputDirectory>
+      <includes>
+        <include>**/*</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory><#noparse>${project.artifactId}/</#noparse></outputDirectory>
+      <useProjectArtifact>true</useProjectArtifact>
+      <useTransitiveFiltering>true</useTransitiveFiltering>
+      <excludes>
+        <exclude>org.apache.kafka:connect-api</exclude>
+      </excludes>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/tooling/camel-kafka-connector-generator-maven-plugin/src/test/resources/template-connector-pom.xml
+++ b/tooling/camel-kafka-connector-generator-maven-plugin/src/test/resources/template-connector-pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.kafkaconnector</groupId>
+        <artifactId>connectors</artifactId>
+        <version>${version}</version>
+    </parent>
+
+    <artifactId>camel-${componentSanitizedName}-kafka-connector</artifactId>
+    <name>Camel-Kafka-Connector :: ${componentName}</name>
+    <description>Camel Kafka Connector for ${componentDescription}</description>
+
+    <dependencies>
+        <!-- Kafka -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-transforms</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Camel -->
+        <dependency>
+            <groupId>${dependencyGroup}</groupId>
+            <artifactId>${dependencyId}</artifactId>
+        </dependency>
+        <!--START OF GENERATED CODE-->
+        <!--END OF GENERATED CODE-->
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version><#noparse>${version.maven.surefire.plugin}</#noparse></version>
+                <configuration>
+                    <failIfNoTests>false</failIfNoTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version><#noparse>${version.maven.jar}</#noparse></version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.5.1</version>
+                <inherited>true</inherited>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.5.3</version>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/assembly/package.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tooling/pom.xml
+++ b/tooling/pom.xml
@@ -43,13 +43,14 @@
         <jdk.version>1.8</jdk.version>
         <compiler.fork>false</compiler.fork>
 
-        <jakarta-jaxb-version>2.3.2</jakarta-jaxb-version>
-        <mvel-version>2.4.12.Final</mvel-version>
-        <gson-version>2.8.5</gson-version>
         <asciidoctorj-version>2.1.0</asciidoctorj-version>
-        <roaster-version>2.20.1.Final</roaster-version>
-        <jandex-version>2.1.1.Final</jandex-version>
         <freemarker-version>2.3.29</freemarker-version>
+        <gson-version>2.8.5</gson-version>
+        <itf-jupiter-extension-version>0.9.0</itf-jupiter-extension-version>
+        <jakarta-jaxb-version>2.3.2</jakarta-jaxb-version>
+        <jandex-version>2.1.1.Final</jandex-version>
+        <mvel-version>2.4.12.Final</mvel-version>
+        <roaster-version>2.20.1.Final</roaster-version>
     </properties>
 
     <build>


### PR DESCRIPTION
Fix #166

Initial attempt at introducing maven it to ckc maven plugin. Running the tests is time consuming, so it's intentionally not integrated with the `integration-test` build cycle by default. You can run them by:
```
mvn clean verify -Pmaven-it
```
at this moment.