### PR TITLE
Convert the CXF sink test case to use the base Sink test class

### DIFF
--- a/tests/itests-cxf/pom.xml
+++ b/tests/itests-cxf/pom.xml
@@ -94,6 +94,11 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+
     </dependencies>
 
 

--- a/tests/itests-cxf/src/test/java/org/apache/camel/kafkaconnector/cxf/common/HelloService.java
+++ b/tests/itests-cxf/src/test/java/org/apache/camel/kafkaconnector/cxf/common/HelloService.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.camel.kafkaconnector.cxf.source;
+package org.apache.camel.kafkaconnector.cxf.common;
 
 import java.util.List;
 

--- a/tests/itests-cxf/src/test/java/org/apache/camel/kafkaconnector/cxf/sink/HelloServiceImpl.java
+++ b/tests/itests-cxf/src/test/java/org/apache/camel/kafkaconnector/cxf/sink/HelloServiceImpl.java
@@ -18,7 +18,7 @@ package org.apache.camel.kafkaconnector.cxf.sink;
 
 import java.util.List;
 
-import org.apache.camel.kafkaconnector.cxf.source.HelloService;
+import org.apache.camel.kafkaconnector.cxf.common.HelloService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/tests/itests-cxf/src/test/java/org/apache/camel/kafkaconnector/cxf/sink/SinkServerFactoryBeanConfigurator.java
+++ b/tests/itests-cxf/src/test/java/org/apache/camel/kafkaconnector/cxf/sink/SinkServerFactoryBeanConfigurator.java
@@ -16,8 +16,8 @@
  */
 package org.apache.camel.kafkaconnector.cxf.sink;
 
+import org.apache.camel.kafkaconnector.cxf.common.HelloService;
 import org.apache.camel.kafkaconnector.cxf.services.ServerFactoryBeanConfigurator;
-import org.apache.camel.kafkaconnector.cxf.source.HelloService;
 import org.apache.cxf.frontend.ServerFactoryBean;
 
 class SinkServerFactoryBeanConfigurator implements ServerFactoryBeanConfigurator {

--- a/tests/itests-cxf/src/test/java/org/apache/camel/kafkaconnector/cxf/source/CamelSourceCXFITCase.java
+++ b/tests/itests-cxf/src/test/java/org/apache/camel/kafkaconnector/cxf/source/CamelSourceCXFITCase.java
@@ -25,6 +25,7 @@ import org.apache.camel.kafkaconnector.common.clients.kafka.KafkaClient;
 import org.apache.camel.kafkaconnector.common.utils.NetworkUtils;
 import org.apache.camel.kafkaconnector.common.utils.TestUtils;
 import org.apache.camel.kafkaconnector.cxf.client.CXFServiceUtil;
+import org.apache.camel.kafkaconnector.cxf.common.HelloService;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,7 +44,7 @@ public class CamelSourceCXFITCase extends AbstractKafkaTest {
     protected static final int PORT = NetworkUtils.getFreePort("localhost");
     protected static final String SIMPLE_ENDPOINT_ADDRESS = "http://localhost:" + PORT + "/CxfConsumerTest/test";
     protected static final String SIMPLE_ENDPOINT_URI = SIMPLE_ENDPOINT_ADDRESS
-            + "?serviceClass=org.apache.camel.kafkaconnector.cxf.source.HelloService"
+            + "?serviceClass=org.apache.camel.kafkaconnector.cxf.common.HelloService"
             + "&publishedEndpointUrl=http://www.simple.com/services/test";
 
     private static final String TEST_MESSAGE = "Hello World!";
@@ -104,7 +105,7 @@ public class CamelSourceCXFITCase extends AbstractKafkaTest {
         try {
             ConnectorPropertyFactory connectorPropertyFactory = CamelSourceCXFPropertyFactory.basic()
                     .withKafkaTopic(TestUtils.getDefaultTestTopic(this.getClass())).withAddress(SIMPLE_ENDPOINT_ADDRESS)
-                    .withServiceClass("org.apache.camel.kafkaconnector.cxf.source.HelloService");
+                    .withServiceClass("org.apache.camel.kafkaconnector.cxf.common.HelloService");
 
             runBasicStringTest(connectorPropertyFactory);
         } catch (Exception e) {
@@ -134,7 +135,7 @@ public class CamelSourceCXFITCase extends AbstractKafkaTest {
         try {
             ConnectorPropertyFactory connectorPropertyFactory = CamelSourceCXFPropertyFactory.basic()
                     .withKafkaTopic(TestUtils.getDefaultTestTopic(this.getClass())).withAddress(SIMPLE_ENDPOINT_ADDRESS)
-                    .withServiceClass("org.apache.camel.kafkaconnector.cxf.source.HelloService").withDataFormat("POJO");
+                    .withServiceClass("org.apache.camel.kafkaconnector.cxf.common.HelloService").withDataFormat("POJO");
 
             runBasicStringTest(connectorPropertyFactory);
         } catch (Exception e) {

--- a/tests/itests-cxf/src/test/resources/hello-service-test.xml
+++ b/tests/itests-cxf/src/test/resources/hello-service-test.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap:Body>
+        <ns1:echo xmlns:ns1="http://source.cxf.kafkaconnector.camel.apache.org/">
+            <arg0 xmlns="http://source.cxf.kafkaconnector.camel.apache.org/">hello world</arg0>
+        </ns1:echo>
+    </soap:Body>
+</soap:Envelope>

--- a/tests/itests-cxf/src/test/resources/jaxws-test.xml
+++ b/tests/itests-cxf/src/test/resources/jaxws-test.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap:Body>
+        <ns1:greetMe xmlns:ns1="http://apache.org/hello_world_soap_http/types">
+            <requestType xmlns="http://apache.org/hello_world_soap_http/types">hello world!</requestType>
+        </ns1:greetMe>
+    </soap:Body>
+</soap:Envelope>


### PR DESCRIPTION
- Move common test code to a common package
- Remove exception handling code
- Move the request to separate files