### PR TITLE
Fix Netty tests reliability

### DIFF
--- a/tests/itests-netty/src/test/java/org/apache/camel/kafkaconnector/netty/sink/CamelSinkNettyITCase.java
+++ b/tests/itests-netty/src/test/java/org/apache/camel/kafkaconnector/netty/sink/CamelSinkNettyITCase.java
@@ -31,7 +31,6 @@ import org.apache.camel.kafkaconnector.common.test.CamelSinkTestSupport;
 import org.apache.camel.kafkaconnector.common.utils.NetworkUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,10 +38,9 @@ import org.slf4j.LoggerFactory;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class CamelSinkNettyITCase extends CamelSinkTestSupport {
     private static final Logger LOG = LoggerFactory.getLogger(CamelSinkNettyITCase.class);
-    private static final int PORT = NetworkUtils.getFreePort("localhost");
+    private final int port = NetworkUtils.getFreePort();
 
     private String topicName;
 
@@ -62,7 +60,7 @@ public class CamelSinkNettyITCase extends CamelSinkTestSupport {
 
     @Override
     protected void consumeMessages(CountDownLatch latch) {
-        try (ServerSocket serverSocket = new ServerSocket(PORT);
+        try (ServerSocket serverSocket = new ServerSocket(port);
              Socket socket = serverSocket.accept();
              InputStream is = socket.getInputStream();
              BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
@@ -92,8 +90,8 @@ public class CamelSinkNettyITCase extends CamelSinkTestSupport {
                 .withTopics(topicName)
                 .withProtocol("tcp")
                 // TODO https://github.com/apache/camel-kafka-connector/issues/924
-                .withHost("//localhost")
-                .withPort(PORT)
+                .withHost("//" + NetworkUtils.getHostname())
+                .withPort(port)
                 // disconnect so that it won't keep mock server socket forever
                 .withDisconnect(true)
                 // one-way as mock server doesn't send replies
@@ -107,7 +105,7 @@ public class CamelSinkNettyITCase extends CamelSinkTestSupport {
     public void testBasicSendReceiveUsingUrl() throws Exception {
         ConnectorPropertyFactory connectorPropertyFactory = CamelNettyPropertyFactory.basic()
                 .withTopics(topicName)
-                .withUrl("tcp", "localhost", PORT)
+                .withUrl("tcp", NetworkUtils.getHostname(), port)
                 // disconnect so that it won't keep mock server socket forever
                 .append("disconnect", "true")
                 // one-way as mock server doesn't send replies

--- a/tests/itests-netty/src/test/java/org/apache/camel/kafkaconnector/netty/source/CamelSourceNettyITCase.java
+++ b/tests/itests-netty/src/test/java/org/apache/camel/kafkaconnector/netty/source/CamelSourceNettyITCase.java
@@ -26,15 +26,13 @@ import org.apache.camel.kafkaconnector.common.test.TestMessageConsumer;
 import org.apache.camel.kafkaconnector.common.utils.NetworkUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class CamelSourceNettyITCase extends CamelSourceTestSupport {
-    private static final int PORT = NetworkUtils.getFreePort("localhost");
+    private final int port = NetworkUtils.getFreePort();
 
     private final int expect = 1;
     private String topicName;
@@ -60,7 +58,7 @@ public class CamelSourceNettyITCase extends CamelSourceTestSupport {
     }
 
     void sendMessage() {
-        try (Socket s = new Socket("localhost", PORT);
+        try (Socket s = new Socket(NetworkUtils.getHostname(), port);
              PrintWriter out = new PrintWriter(s.getOutputStream())) {
             out.print("Hello CKC!");
             out.flush();
@@ -85,8 +83,8 @@ public class CamelSourceNettyITCase extends CamelSourceTestSupport {
                 .withKafkaTopic(topicName)
                 .withProtocol("tcp")
                 // TODO https://github.com/apache/camel-kafka-connector/issues/924
-                .withHost("//localhost")
-                .withPort(PORT)
+                .withHost("//" + NetworkUtils.getHostname())
+                .withPort(port)
                 // one-way as test client doesn't receive response
                 .withSync(false);
 
@@ -99,7 +97,7 @@ public class CamelSourceNettyITCase extends CamelSourceTestSupport {
         CamelNettyPropertyFactory connectorPropertyFactory = CamelNettyPropertyFactory
                 .basic()
                 .withKafkaTopic(topicName)
-                .withUrl("tcp", "localhost", PORT)
+                .withUrl("tcp", NetworkUtils.getHostname(), port)
                 // one-way as test client doesn't receive response
                 .append("sync", "false")
                 .buildUrl();


### PR DESCRIPTION
- avoid per class lifecycle since it seems to cause the code to try to bind the same port multiple times
- do not assume local hostnames and/or that they are correctly configured