### PR TITLE
README - fix link to 'getting started guide'

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -36,4 +36,4 @@ link:./docs/modules/ROOT/pages/testing.adoc[testing guide].
 
 == Documentation
 
-Read the https://camel.apache.org/camel-kafka-connector/latest/index.html[Official latest documentation] or try the local link:./docs/modules/ROOT/pages/getting-started.adoc[Getting started guide].
+Read the https://camel.apache.org/camel-kafka-connector/latest/index.html[Official latest documentation] or try the local link:./docs/modules/ROOT/pages/user-guide/index.adoc[Getting started guide].


### PR DESCRIPTION
https://github.com/apache/camel-kafka-connector/blob/main/docs/modules/ROOT/pages/getting-started.adoc - 404


Is this the intended link? 

https://github.com/apache/camel-kafka-connector/blob/main/docs/modules/ROOT/pages/user-guide/index.adoc