### PR TITLE
Camel kafka connector 0.11.x local index page and local/partial build

### DIFF
--- a/docs/indexPages.yml
+++ b/docs/indexPages.yml
@@ -1,0 +1,14 @@
+indexPages:
+  - query:
+      module: ROOT
+      family: example
+      relative: json/*
+    template-id:
+      family: example
+      relative: template/connector-options.adoc
+    extract:
+      - path: 'src.relative'
+        match: 'json/camel-(?<basename>*)-kafka-(?<type>source|sink)-connector.json'
+    target:
+      match: 'json/(?<body>*).json'
+      format: '`reference/connectors/${body}.adoc`'

--- a/docs/local-build.sh
+++ b/docs/local-build.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+CW=./../../camel-website
+LOCAL=./../camel-kafka-connector
+
+cd $CW || (echo 'camel-website not in expected location $CW' && exit)
+cp antora-playbook.yml local-antora-playbook-full.yml
+cat $LOCAL/docs/source-map.yml >> local-antora-playbook-full.yml
+cat playbook-patch-full.yml >> local-antora-playbook-full.yml
+
+cp antora-playbook.yml local-antora-playbook-partial.yml
+cat $LOCAL/docs/source-map.yml >> local-antora-playbook-partial.yml
+cat $LOCAL/docs/source-watch.yml >> local-antora-playbook-partial.yml
+
+if [ "$1" = "full" ] || [ "$1" = "1" ]
+then
+  yarn build:antora-local-full
+else
+  yarn build:antora-local-partial
+fi

--- a/docs/source-map.yml
+++ b/docs/source-map.yml
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+    - require: '@djencks/antora-source-map'
+#      log_level: trace
+      source-map:
+        - url: 'https://github.com/apache/camel-kafka-connector.git'
+          mapped-url: './../camel-kafka-connector'
+          branches:
+            - branch: camel-kafka-connector-0.11.x
+              mapped-branch: HEAD

--- a/docs/source-watch.yml
+++ b/docs/source-watch.yml
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+    - require: '@djencks/antora-source-watch'
+#      log_level: trace
+      sources:
+        - url: ./../camel-kafka-connector
+          component: camel-kafka-connector
+          version: next
+
+    - require: "@djencks/antora-site-manifest"
+      import-manifests:
+        - primary-site-manifest-url: ./documentation/site-manifest.json
+      partial-components: true
+      local-urls: true
+
+    - require: '@djencks/antora-timer'
+      log_level: info
+
+  generator: '@djencks/antora-source-watch'


### PR DESCRIPTION
This sets up the local/partial build structure for ckc and prepares for moving the playbook config for the page generation to a local file.
(0.11.x branch)