### PR TITLE
Fix Maven IT failures due to doc generation removal

### DIFF
--- a/tooling/camel-kafka-connector-generator-maven-plugin/src/test/java/org/apache/camel/kafkaconnector/maven/GenerateCamelKafkaConnectorsMojoIT.java
+++ b/tooling/camel-kafka-connector-generator-maven-plugin/src/test/java/org/apache/camel/kafkaconnector/maven/GenerateCamelKafkaConnectorsMojoIT.java
@@ -68,8 +68,7 @@ class GenerateCamelKafkaConnectorsMojoIT {
             .anyMatch(s -> s.startsWith("Connectors previously generated found to be removed: []"))
             .containsSequence(
                 "Creating a new pom.xml for the connector from scratch",
-                "Creating a new package.xml for the connector.")
-            .anyMatch(s -> s.startsWith("Updated doc file:"));
+                "Creating a new package.xml for the connector.");
 
         List<String> stdout = Files.readAllLines(result.getMavenLog().getStdout());
         List<String> generated = extractGenerated(stdout);


### PR DESCRIPTION
Caused by commit 281fc53d7a65455dafffec7bc2170aff22a1922b

Sorry, I finally have found time to revisit the Maven IT issue. I think this fixes it.

@djencks Just FYI, sometimes changes to the Maven plugin cause an error to the daily Maven IT CI. It'd be great if we keep an eye on the results when we touch the Maven plugins. Thanks.