### PR TITLE
camel-website #701: RI info (1.0.x)

### DIFF
--- a/connectors/antora.yml
+++ b/connectors/antora.yml
@@ -1,5 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 # A distributed part of the component at /docs/antora.yml
 
 name: camel-kafka-connector
-version: next
+version: 1.0.x

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,8 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Another part of this distributed component is at components/antora.yml
+
 name: camel-kafka-connector
 title: Camel Kafka Connector
-version: next
-prerelease: true
-display-version: Next (Pre-release)
-
+version: 1.0.x
+display_version: 1.0.x (LTS)
 nav:
 - modules/ROOT/nav.adoc
+
+asciidoc:
+  attributes:
+    LTS: January 2023
+    camel-version: 3.14.0
+    camel-docs-version: 3.14.x
+    camel-kamelets-version: 0.6.0
+    camel-kamelets-docs-version: 0.6.x
+    kafka-version: 2.8.0

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,6 +1,21 @@
 [[WhatIsIt-WhatIsIt]]
 = Camel Kafka Connector
 
+[NOTE]
+--
+This version ({page-component-display-version}) of {page-component-title} depends on:
+
+* https://kafka.apache.org[Apache Kafka] at version {kafka-version}
+* xref:{camel-docs-version}@components::index.adoc[Camel] at version {camel-version}
+* xref:{camel-kamelets-docs-version}@camel-kamelets::index.adoc[Camel Kamelets] at version {camel-kamelets-version}
+
+ifdef::lts[This long term service release will be supported until {lts}.]
+ifndef::lts[]
+ifdef::prerelease[This is the development version of {page-component-title}. It should not be used in production.]
+ifndef::prerelease[This release will not be updated, but rather replaced by a new release.]
+endif::[]
+--
+
 Camel Kafka Connector allows you to use all Camel xref:components::index.adoc[components] as http://kafka.apache.org/documentation/#connect[Kafka Connect] connectors.
 
 The basic idea is reusing the available Camel components as Kafka sink and source connectors in a simple way.


### PR DESCRIPTION
See apache/camel-website#701

Note that:
- the vote for 1.0.0 has not yet completed. Presumably it should complete before this is applied?
- This uses the Antora version 1.0.x.  I suggest we change the 0.11.x Antora version from 0.11.0 to 0.11.x similarly.
- The vote doesn't indicate this is LTS, so I said it wasn't.