### PR TITLE
camel-website #701: RI info (0.11.x)

### DIFF
--- a/connectors/antora.yml
+++ b/connectors/antora.yml
@@ -1,5 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 # A distributed part of the component at /docs/antora.yml
 
 name: camel-kafka-connector
-version: 0.11.0
+version: 0.11.x

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -15,14 +15,22 @@
 # limitations under the License.
 #
 
+# Another part of this distributed component is at components/antora.yml
+
 name: camel-kafka-connector
 title: Camel Kafka Connector
-version: 0.11.0
-display_version: 0.11.0 (LTS)
+version: 0.11.x
+display_version: 0.11.x (LTS)
 
 nav:
 - modules/ROOT/nav.adoc
 
 asciidoc:
   attributes:
-    camel-version: 3.11.x
+#    based on vote thread https://lists.apache.org/thread/957zf5r8gwd5r0pmrot9j451s065jgmz 9/24/2021 (or 24/9/2021)
+    lts: September 2022
+    camel-version: 3.11.1
+    camel-docs-version: 3.11.x
+#    camel-kamelets-version: 0.6.0
+#    camel-kamelets-docs-version: 0.6.x
+    kafka-version: 2.8.0

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,6 +1,21 @@
 [[WhatIsIt-WhatIsIt]]
 = Camel Kafka Connector
 
+[NOTE]
+--
+This version ({page-component-display-version}) of {page-component-title} depends on:
+
+* https://kafka.apache.org[Apache Kafka] at version {kafka-version}
+* xref:{camel-docs-version}@components::index.adoc[Camel] at version {camel-version}
+//* xref:{camel-kamelets-docs-version}@camel-kamelets::index.adoc[Camel Kamelets] at version {camel-kamelets-version}
+
+ifdef::lts[This long term service release will be supported until {lts}.]
+ifndef::lts[]
+ifdef::prerelease[This is the development version of {page-component-title}. It should not be used in production.]
+ifndef::prerelease[This release will not be updated, but rather replaced by a new release.]
+endif::[]
+--
+
 Camel Kafka Connector allows you to use all Camel xref:components::index.adoc[components] as http://kafka.apache.org/documentation/#connect[Kafka Connect] connectors.
 
 The basic idea is reusing the available Camel components as Kafka sink and source connectors in a simple way.

--- a/docs/modules/ROOT/pages/user-guide/aggregation.adoc
+++ b/docs/modules/ROOT/pages/user-guide/aggregation.adoc
@@ -4,7 +4,7 @@
 In a Sink Connector scenario, there are, sometimes, use cases where an end user want to aggregate his Kafka record before sending them to an external system. 
 Usually this can be done by defining a batch size or a timeout and once the aggregation has been completed, sent the aggregate records collection to the external system.
 
-In Apache Camel it exists the xref:{camel-version}@components:eips:aggregate-eip.adoc[Aggregate EIP] implementation and in Camel-Kafka-connector we wanted to leverage what we already have in the plain Apache Camel project.
+In Apache Camel it exists the xref:{camel-docs-version}@components:eips:aggregate-eip.adoc[Aggregate EIP] implementation and in Camel-Kafka-connector we wanted to leverage what we already have in the plain Apache Camel project.
 
 We introduced then the following options in the Sink Connector Configuration:
 


### PR DESCRIPTION
See apache/camel-website#701

This does not alter the Antora version of 0.11.0, although I think it should be changed to 0.11.x.