### PR TITLE
Could org.apache.camel.kafkaconnector:camel-kafka-connector-catalog-descriptor-maven-plugin:1.1.0-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/tooling/camel-kafka-connector-catalog-descriptor-maven-plugin/pom.xml
+++ b/tooling/camel-kafka-connector-catalog-descriptor-maven-plugin/pom.xml
@@ -52,6 +52,24 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>${maven-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.sonatype.plexus</groupId>
+                    <artifactId>plexus-sec-dispatcher</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.inject</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-component-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -72,11 +90,23 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-compat</artifactId>
             <version>${maven-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-component-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-dependency-tree</artifactId>
             <version>3.0.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-component-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
@@ -85,10 +115,6 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.sonatype.plexus</groupId>
-            <artifactId>plexus-build-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
Hi! I found the pom file of project **_org.apache.camel.kafkaconnector:camel-kafka-connector-catalog-descriptor-maven-plugin:1.1.0-SNAPSHOT_** introduced **_49_** dependencies. However, among them, **_7_** libraries (**_14%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
org.sonatype.plexus:plexus-sec-dispatcher:jar:1.4:compile
org.sonatype.plexus:plexus-cipher:jar:1.4:compile
javax.enterprise:cdi-api:jar:1.0:compile
javax.annotation:jsr250-api:jar:1.0:compile
javax.inject:javax.inject:jar:1:compile
org.codehaus.plexus:plexus-component-annotations:jar:2.1.0:compile
org.sonatype.plexus:plexus-build-api:jar:0.0.7:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_org.codehaus.plexus:plexus-component-annotations:jar:2.1.0:compile_** induced dependency conflict in the dependency graph. As such, I suggest a refactoring operation for **_org.apache.camel.kafkaconnector:camel-kafka-connector-catalog-descriptor-maven-plugin:1.1.0-SNAPSHOT_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_org.apache.camel.kafkaconnector:camel-kafka-connector-catalog-descriptor-maven-plugin:1.1.0-SNAPSHOT_**’s maven tests.

Best regards
![image](https://user-images.githubusercontent.com/78527112/160523991-ba218723-08d2-4d91-acac-6e54a33cf7f4.png)
