### PR TITLE
Update try-it-out-locally.adoc

### DIFF
--- a/docs/modules/ROOT/pages/user-guide/getting-started/try-it-out-locally.adoc
+++ b/docs/modules/ROOT/pages/user-guide/getting-started/try-it-out-locally.adoc
@@ -56,7 +56,7 @@ plugin.path=/home/connectors
 
 At this point you're able to run the connectors quickstart.
 
-Next, run Camel kafka connectors source and/or syncs:
+Next, run Camel kafka connectors source and/or sink:
 
 You can use these Kafka utilities to listen or produce from a Kafka topic:
 


### PR DESCRIPTION
Kafka uses source/sink terminology for data source and target systems. I think 'sink' has been mistakenly written as 'sync'.