### PR TITLE
fix: salesforce kamelet file for update operation

### DIFF
--- a/connectors/camel-salesforce-update-sink-kafka-connector/pom.xml
+++ b/connectors/camel-salesforce-update-sink-kafka-connector/pom.xml
@@ -42,8 +42,16 @@
     <!-- Camel -->
     <!--START OF GENERATED CODE-->
     <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-jackson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.camel.kafkaconnector</groupId>
       <artifactId>camel-kafka-connector</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-jsonpath</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>

--- a/connectors/camel-salesforce-update-sink-kafka-connector/src/main/resources/kamelets/salesforce-update-sink.kamelet.yaml
+++ b/connectors/camel-salesforce-update-sink-kafka-connector/src/main/resources/kamelets/salesforce-update-sink.kamelet.yaml
@@ -91,6 +91,9 @@ spec:
     in:
       mediaType: application/json
   dependencies:
+  - 'camel:core'
+  - "camel:jsonpath"
+  - "camel:jackson"
   - "camel:salesforce"
   - "camel:kamelet"
   template:
@@ -106,9 +109,14 @@ spec:
     from:
       uri: kamelet:source
       steps:
-        - to:
-            uri: "{{local-salesforce}}:updateSObject"
-            parameters:
-              sObjectId: "{{sObjectId}}"
-              sObjectName: "{{sObjectName}}"
-              rawPayload: "true"
+        - set-property:
+            name: sObjectId
+            jsonpath: "$['sObjectId']"
+        - set-property:
+            name: sObjectName
+            jsonpath: "$['sObjectName']"
+        - transform:
+            jsonpath: "$.payload"
+        - marshal:
+            json: {}
+        - toD: "{{local-salesforce}}:updateSObject?sObjectId=${exchangeProperty.sObjectId}&sObjectName=${exchangeProperty.sObjectName}&rawPayload=true"


### PR DESCRIPTION
Fixing the kamelet file for salesforce update sink. Today this file only accepts the fields `sObjectId` and `sObjectName` by properties.

Even if i use the header-to-property mapper does not work. So i made some modifications to use the sink dynamically.