### PR TITLE
ci: fix broken build - define squareup-okhttp-version for itests

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -37,6 +37,9 @@
         <version.javax.annotation-api>1.3.2</version.javax.annotation-api>
         <version.postgres>42.4.4</version.postgres>
         <version.jctools>3.3.0</version.jctools>
+        <!-- okhttp/mockwebserver for itests: owned here because camel-dependencies
+             renamed squareup-okhttp-version to squareup-okhttp5-version in 4.21 -->
+        <squareup-okhttp-version>3.14.9</squareup-okhttp-version>
 
         <version.maven.compiler>3.13.0</version.maven.compiler>
         <version.maven.javadoc>3.6.3</version.maven.javadoc>


### PR DESCRIPTION
## Problem

The build is broken on `main` (and on every PR) at Maven's project-scanning
phase:

```
[ERROR] 'dependencies.dependency.version' for com.squareup.okhttp3:okhttp:jar
        must be a valid version but is '${squareup-okhttp-version}'.
        @ org.apache.camel.kafkaconnector:itests-parent:4.21.0-SNAPSHOT,
        tests/itests-parent/pom.xml, line 214
...
[ERROR] The build could not read 3 projects
```

`tests/itests-parent/pom.xml` has referenced `${squareup-okhttp-version}` for
the okhttp3 / mockwebserver test dependencies since 2021, resolving it from the
inherited Apache Camel `camel-dependencies` BOM.

In **Camel 4.21** that property was migrated to okhttp 5 and **renamed**
`squareup-okhttp-version` → `squareup-okhttp5-version`. After
`535240277e (ci: bump camel version from 4.19.0-SNAPSHOT to 4.21.0-SNAPSHOT)`
the old name no longer resolves, so the whole reactor fails to be read.

## Fix

Define `squareup-okhttp-version` in CKC's own `parent/pom.xml` at `3.14.9` —
the exact value Camel carried through the 4.x line before the okhttp5
migration, matching the okhttp3 `okhttp3.mockwebserver.MockWebServer` /
`MockResponse` API the itests actually use
(`tests/itests-common-http/.../mockweb/MockWebService.java`). Owning the
property in CKC decouples it from future `camel-dependencies` property
renames.

- One property, no code changes, no new dependency, no API change.
- okhttp **3.x** is kept deliberately: bumping to the Camel-4.21 okhttp 5
  line would break compilation of the existing MockWebServer-based itests
  (okhttp 5 repackaged `MockWebServer` to `mockwebserver3`). That migration,
  if wanted, is a separate change.

## Verification

`./mvnw validate` over the `:camel-kafka-connector-model` /
`:camel-kafka-connector-generator-maven-plugin` / `:camel-kafka-connector`
reactor set (the CI "Build model" module set) now completes — previously it
aborted with "could not read 3 projects".

---

_Claude Code on behalf of Andrea Cosentino_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
