### PR TITLE
Fix #1795: use unmarshal instead of marshal in ckcUnMarshal route template

### DIFF
--- a/core/src/main/java/org/apache/camel/kafkaconnector/utils/CamelKafkaConnectMain.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/utils/CamelKafkaConnectMain.java
@@ -316,7 +316,7 @@ public class CamelKafkaConnectMain extends SimpleMain {
                     routeTemplate("ckcUnMarshal")
                             .templateParameter("unmarshal", "dummyDataformat")
                             .from("kamelet:source")
-                            .marshal("{{unmarshal}}")
+                            .unmarshal("{{unmarshal}}")
                             .to("kamelet:sink");
 
                     //create aggregator template

--- a/core/src/test/java/org/apache/camel/kafkaconnector/DataFormatTest.java
+++ b/core/src/test/java/org/apache/camel/kafkaconnector/DataFormatTest.java
@@ -23,9 +23,12 @@ import org.apache.camel.component.hl7.HL7DataFormat;
 import org.apache.camel.component.syslog.SyslogDataFormat;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.kafkaconnector.utils.CamelKafkaConnectMain;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.syslog.SyslogMessage;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -98,6 +101,33 @@ public class DataFormatTest {
         assertNotNull(hl7dfLoaded);
         SyslogDataFormat syslogDfLoaded = (SyslogDataFormat)dcc.resolveDataFormat("syslog");
         assertNotNull(syslogDfLoaded);
+        cms.stop();
+    }
+
+    @Test
+    public void testUnmarshalRouteActuallyUnmarshals() throws Exception {
+        // https://github.com/apache/camel-kafka-connector/issues/1795
+        // ckcUnMarshal previously called .marshal() instead of .unmarshal(),
+        // so the body never actually got converted to the target type.
+        Map<String, String> props = new HashMap<>();
+        props.put("camel.source.url", "direct://test");
+        props.put("topics", "mytopic");
+        props.put("camel.source.unmarshal", "syslog");
+
+        DefaultCamelContext dcc = new DefaultCamelContext();
+        CamelKafkaConnectMain cms = CamelKafkaConnectMain.builder("direct://start", "log://test")
+            .withProperties(props)
+            .withUnmarshallDataFormat("syslog")
+            .build(dcc);
+
+        SyslogDataFormat syslogDf = new SyslogDataFormat();
+        dcc.getRegistry().bind("syslog", syslogDf);
+
+        cms.start();
+        ProducerTemplate template = dcc.createProducerTemplate();
+        String rawSyslogLine = "<34>Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8";
+        Object result = template.requestBody("direct://start", rawSyslogLine);
+        assertInstanceOf(SyslogMessage.class, result);
         cms.stop();
     }
 


### PR DESCRIPTION
Closes #1795.

The ckcUnMarshal route template called .marshal("{{unmarshal}}") instead of .unmarshal("{{unmarshal}}"), so the configured unmarshal dataformat never actually converted the incoming body, it stayed as the raw stream. This affects any connector using camel.source.unmarshal, syslog is what surfaced it in the original report, but the same problem applies to every dataformat routed through this template.

Added a regression test that sends a real syslog line through the route and asserts the body actually comes out as a SyslogMessage. Confirmed it fails with the right error against the old code (body stayed an InputStreamCache instead of getting converted) before restoring the fix.