### PR TITLE
Fix #1795: ckcUnMarshal route template applies unmarshal instead of marshal

### DIFF
--- a/core/src/main/java/org/apache/camel/kafkaconnector/utils/CamelKafkaConnectMain.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/utils/CamelKafkaConnectMain.java
@@ -316,7 +316,7 @@ public class CamelKafkaConnectMain extends SimpleMain {
                     routeTemplate("ckcUnMarshal")
                             .templateParameter("unmarshal", "dummyDataformat")
                             .from("kamelet:source")
-                            .marshal("{{unmarshal}}")
+                            .unmarshal("{{unmarshal}}")
                             .to("kamelet:sink");
 
                     //create aggregator template

--- a/core/src/test/java/org/apache/camel/kafkaconnector/DataFormatTest.java
+++ b/core/src/test/java/org/apache/camel/kafkaconnector/DataFormatTest.java
@@ -16,19 +16,25 @@
  */
 package org.apache.camel.kafkaconnector;
 
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.camel.Exchange;
 import org.apache.camel.component.hl7.HL7DataFormat;
 import org.apache.camel.component.syslog.SyslogDataFormat;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.kafkaconnector.utils.CamelKafkaConnectMain;
+import org.apache.camel.spi.DataFormat;
+import org.apache.camel.support.service.ServiceSupport;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DataFormatTest {
 
@@ -143,5 +149,79 @@ public class DataFormatTest {
         HL7DataFormat hl7dfLoaded = (HL7DataFormat)dcc.resolveDataFormat("hl7");
         assertFalse(hl7dfLoaded.isValidate());
         cms.stop();
+    }
+
+    @Test
+    public void testUnmarshalDataFormatIsAppliedInTheUnmarshalDirection() throws Exception {
+        DirectionRecordingDataFormat dataFormat = new DirectionRecordingDataFormat();
+        DefaultCamelContext dcc = new DefaultCamelContext();
+        dcc.getRegistry().bind("directionRecording", dataFormat);
+
+        CamelKafkaConnectMain cms = CamelKafkaConnectMain.builder("direct://start", "log://test")
+            .withProperties(new HashMap<String, String>())
+            .withUnmarshallDataFormat("directionRecording")
+            .build(dcc);
+
+        cms.start();
+        cms.getProducerTemplate().sendBody("direct://start", "payload");
+        cms.stop();
+
+        assertTrue(dataFormat.isUnmarshalled(), "camel.*.unmarshal must apply the data format in the unmarshal direction");
+        assertFalse(dataFormat.isMarshalled(), "camel.*.unmarshal must not apply the data format in the marshal direction");
+    }
+
+    @Test
+    public void testMarshalDataFormatIsAppliedInTheMarshalDirection() throws Exception {
+        DirectionRecordingDataFormat dataFormat = new DirectionRecordingDataFormat();
+        DefaultCamelContext dcc = new DefaultCamelContext();
+        dcc.getRegistry().bind("directionRecording", dataFormat);
+
+        CamelKafkaConnectMain cms = CamelKafkaConnectMain.builder("direct://start", "log://test")
+            .withProperties(new HashMap<String, String>())
+            .withMarshallDataFormat("directionRecording")
+            .build(dcc);
+
+        cms.start();
+        cms.getProducerTemplate().sendBody("direct://start", "payload");
+        cms.stop();
+
+        assertTrue(dataFormat.isMarshalled(), "camel.*.marshal must apply the data format in the marshal direction");
+        assertFalse(dataFormat.isUnmarshalled(), "camel.*.marshal must not apply the data format in the unmarshal direction");
+    }
+
+    /**
+     * A data format that only records which direction it was invoked in, so that a test can assert that the route
+     * template applies the operation the configuration actually names.
+     */
+    private static final class DirectionRecordingDataFormat extends ServiceSupport implements DataFormat {
+
+        private boolean marshalled;
+        private boolean unmarshalled;
+
+        @Override
+        public void marshal(Exchange exchange, Object graph, OutputStream stream) throws Exception {
+            marshalled = true;
+            stream.write(exchange.getContext().getTypeConverter().mandatoryConvertTo(byte[].class, exchange, graph));
+        }
+
+        @Override
+        public Object unmarshal(Exchange exchange, InputStream stream) throws Exception {
+            unmarshalled = true;
+            return exchange.getContext().getTypeConverter().mandatoryConvertTo(String.class, exchange, stream);
+        }
+
+        @Override
+        public Object unmarshal(Exchange exchange, Object body) throws Exception {
+            unmarshalled = true;
+            return exchange.getContext().getTypeConverter().mandatoryConvertTo(String.class, exchange, body);
+        }
+
+        boolean isMarshalled() {
+            return marshalled;
+        }
+
+        boolean isUnmarshalled() {
+            return unmarshalled;
+        }
     }
 }


### PR DESCRIPTION
Fixes #1795.

## What

The `ckcUnMarshal` route template was calling `.marshal("{{unmarshal}}")`:

```java
routeTemplate("ckcUnMarshal")
        .templateParameter("unmarshal", "dummyDataformat")
        .from("kamelet:source")
        .marshal("{{unmarshal}}")   // <- applied the wrong direction
        .to("kamelet:sink");
```

so every connector configured with `camel.sink.unmarshal` or `camel.source.unmarshal` got a route
that marshalled the payload instead of unmarshalling it. The reporter hit this as a
`NoTypeConversionAvailableException` on `CamelSyslogSourceConnector`, but it affects every use of
either option.

## Why it regressed

`ca4e784352` ("Related to #423 modularized kamelets and composed them to better autogenerate
connectors from kamelets catalog") extracted the marshal and unmarshal steps into standalone route
templates. Before that commit the route was built directly and was correct:

```java
rdInTemplateSource = rdInTemplateSource.unmarshal("{{unmarshal}}");
```

The new `ckcUnMarshal` template was copied from `ckcMarshal` directly above it and the operation was
never switched over. This PR restores the pre-`ca4e784352` behaviour.

## Test coverage

The existing `DataFormatTest` cases only assert that the context starts and that the data format
resolves — never which direction it is applied in — which is why this passed CI for so long.

Added two tests that push a message through the built route with a data format that records which
direction it was invoked in:

- `testUnmarshalDataFormatIsAppliedInTheUnmarshalDirection`
- `testMarshalDataFormatIsAppliedInTheMarshalDirection`

Confirmed that the first one fails on the unpatched template (`expected: <true> but was: <false>`)
and passes with the fix, so it is a real regression guard.

## Verification

- `core` module: 103/103 tests pass.
- Full reactor build from the repository root (`./mvnw clean install`, all tests): BUILD SUCCESS.

Note the root build also surfaced pre-existing regeneration drift in the checked-in connector tree
(unrelated to this change, and left out of this PR) — filed separately as #1798.