### PR TITLE
Fix #1799: FileTransforms fails the record instead of emitting a null value

### DIFF
--- a/connectors/camel-file-kafka-connector/pom.xml
+++ b/connectors/camel-file-kafka-connector/pom.xml
@@ -49,6 +49,13 @@
       <artifactId>commons-io</artifactId>
       <version>${commons-io-version}</version>
     </dependency>
+    <!-- Test scope; version managed by junit-bom via camel-parent. Kept outside the generated
+         block below so the connector generator does not overwrite it. -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
     <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel.kafkaconnector</groupId>

--- a/connectors/camel-file-kafka-connector/src/main/java/org/apache/camel/kafkaconnector/file/transformers/FileTransforms.java
+++ b/connectors/camel-file-kafka-connector/src/main/java/org/apache/camel/kafkaconnector/file/transformers/FileTransforms.java
@@ -26,6 +26,7 @@ import org.apache.camel.kafkaconnector.utils.SchemaHelper;
 import org.apache.commons.io.FileUtils;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.transforms.Transformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,21 +41,21 @@ public class FileTransforms<R extends ConnectRecord<R>> implements Transformatio
     public R apply(R r) {
         Object value = r.value();
 
-        if (r.value() instanceof GenericFile) {
+        if (value instanceof GenericFile) {
             LOG.debug("Converting record from RemoteFile to text");
-            GenericFile<File> message = (GenericFile<File>)r.value();
-            String c = null;
+            GenericFile<File> message = (GenericFile<File>)value;
+            File file = message.getFile();
+            String c;
             try {
-                c = FileUtils.readFileToString(message.getFile(), StandardCharsets.UTF_8);
+                c = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
             } catch (IOException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
+                throw new ConnectException("Failed to read file " + file.getAbsolutePath(), e);
             }
 
             return r.newRecord(r.topic(), r.kafkaPartition(), null, r.key(), SchemaHelper.buildSchemaBuilderForType(c), c, r.timestamp());
 
         } else {
-            LOG.debug("Unexpected message type: {}", r.value().getClass());
+            LOG.debug("Unexpected message type: {}", value == null ? null : value.getClass());
 
             return r;
         }

--- a/connectors/camel-file-kafka-connector/src/test/java/org/apache/camel/kafkaconnector/file/transformers/FileTransformsTest.java
+++ b/connectors/camel-file-kafka-connector/src/test/java/org/apache/camel/kafkaconnector/file/transformers/FileTransformsTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.kafkaconnector.file.transformers;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.camel.component.file.GenericFile;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class FileTransformsTest {
+
+    @TempDir
+    private Path tempDir;
+
+    private SourceRecord recordOf(Object value) {
+        return new SourceRecord(null, null, "mytopic", 0, null, null, null, value, null);
+    }
+
+    private SourceRecord recordFor(File file) {
+        GenericFile<File> genericFile = new GenericFile<>();
+        genericFile.setFile(file);
+        return recordOf(genericFile);
+    }
+
+    @Test
+    public void testReadsFileContentAsString() throws IOException {
+        File file = tempDir.resolve("content.txt").toFile();
+        Files.write(file.toPath(), "hello".getBytes(StandardCharsets.UTF_8));
+
+        SourceRecord transformed = new FileTransforms<SourceRecord>().apply(recordFor(file));
+
+        assertEquals("hello", transformed.value());
+        assertNotNull(transformed.valueSchema());
+    }
+
+    @Test
+    public void testUnreadableFileFailsTheRecordInsteadOfEmittingANullValue() {
+        File missing = tempDir.resolve("missing.txt").toFile();
+
+        FileTransforms<SourceRecord> transform = new FileTransforms<>();
+        SourceRecord record = recordFor(missing);
+
+        ConnectException e = assertThrows(ConnectException.class, () -> transform.apply(record));
+
+        assertInstanceOf(IOException.class, e.getCause());
+    }
+
+    @Test
+    public void testRecordWithANullValueIsPassedThrough() {
+        SourceRecord record = recordOf(null);
+
+        assertSame(record, new FileTransforms<SourceRecord>().apply(record));
+    }
+
+    @Test
+    public void testRecordOfAnUnexpectedTypeIsPassedThrough() {
+        SourceRecord record = recordOf("not a file");
+
+        assertSame(record, new FileTransforms<SourceRecord>().apply(record));
+    }
+}


### PR DESCRIPTION
Fixes #1799.

## What

`FileTransforms.apply()` carried an Eclipse-generated catch stub:

```java
String c = null;
try {
    c = FileUtils.readFileToString(message.getFile(), StandardCharsets.UTF_8);
} catch (IOException e) {
    // TODO Auto-generated catch block
    e.printStackTrace();
}

return r.newRecord(..., SchemaHelper.buildSchemaBuilderForType(c), c, r.timestamp());
```

A file that could not be read was reported only to stderr, and then `c` was still `null`, so the read
failure was silently turned into a record with a `null` value and a schema derived from `null`.

This PR:

- propagates the failure as a `ConnectException` naming the file, so Kafka Connect's error handling
  and DLQ apply and the failure is attributed to the file that caused it;
- fixes the `else` branch, which called `r.value().getClass()` to log the unexpected type and so
  threw `NullPointerException` for a record whose value is `null`;
- reuses the local `value` (previously assigned and never used) instead of calling `r.value()` three
  times.

## What this deliberately does not do

`FileUtils.readFileToString` still materialises the whole file as one `String`. Capping that would
mean a new SMT option and a default size limit — a behaviour change for existing users, and the
project's Security Model puts resource exhaustion on the operator side ("Denial of service via
resource exhaustion ... operators apply ... JVM heap limits"). Happy to add a cap if you'd prefer,
but it seemed like a separate decision rather than part of fixing the swallowed exception.

## Tests

This is the first test in a connector module (none of the 231 currently have one), so the pom needed
a `junit-jupiter` test dependency. It is placed **before** the `<!--START OF GENERATED CODE-->`
marker so the connector generator does not overwrite it — verified by running the generator via a
full root build, which left it intact. Surefire is already configured in that pom.

Four cases: content is read, an unreadable file raises `ConnectException` with the `IOException` as
cause, a `null` record value passes through, and a record of an unexpected type passes through.

Confirmed both defects are actually caught — against the unpatched transform, two of the four fail:

```
testUnreadableFileFailsTheRecordInsteadOfEmittingANullValue
  expected: <ConnectException> but was: <java.lang.NullPointerException>
testRecordWithANullValueIsPassedThrough
  NullPointer: Cannot invoke "Object.getClass()" because the return value of
  "org.apache.kafka.connect.connector.ConnectRecord.value()" is null
```

## Verification

- `camel-file-kafka-connector`: 4/4 tests pass.
- Full reactor build from the repository root (`./mvnw clean install -DskipTests`): BUILD SUCCESS.

Related: #1786 removed the open TODO/XXX comments in `core`; this one was in a connector module and
was not covered by that sweep.