### PR TITLE
ci: fix checkstyle import order in DataFormatTest

### DIFF
--- a/core/src/test/java/org/apache/camel/kafkaconnector/DataFormatTest.java
+++ b/core/src/test/java/org/apache/camel/kafkaconnector/DataFormatTest.java
@@ -19,17 +19,17 @@ package org.apache.camel.kafkaconnector;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.camel.ProducerTemplate;
 import org.apache.camel.component.hl7.HL7DataFormat;
 import org.apache.camel.component.syslog.SyslogDataFormat;
+import org.apache.camel.component.syslog.SyslogMessage;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.kafkaconnector.utils.CamelKafkaConnectMain;
-import org.apache.camel.ProducerTemplate;
-import org.apache.camel.component.syslog.SyslogMessage;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 


### PR DESCRIPTION
`main` is currently red and every open pull request inherits the failure.

## What broke

`225a5b7ab3` (#1796) appended its new imports instead of sorting them into the existing blocks:

```java
import org.apache.camel.kafkaconnector.utils.CamelKafkaConnectMain;
import org.apache.camel.ProducerTemplate;                    // <- after org.apache.camel.kafkaconnector.*
import org.apache.camel.component.syslog.SyslogMessage;
...
import static org.junit.jupiter.api.Assertions.assertInstanceOf;   // <- before assertFalse
import static org.junit.jupiter.api.Assertions.assertFalse;
```

CI runs checkstyle with `-Psourcecheck -Dcheckstyle.failOnViolation=true`, which rejects this:

```
DataFormatTest.java:26: Wrong order for 'org.apache.camel.ProducerTemplate' import. [ImportOrder]
```

The `Camel Kafka Connect CI` run on `225a5b7a` failed, and because pull request CI builds the merge
commit against `main`, unrelated PRs fail on this same violation — e.g. #1810 and #1811 report it
against a file neither of them touches.

A plain `mvn test` does not run checkstyle, which is presumably how it got through locally.

## Fix

Sort the imports. No behavioural change.

## Verification

- `core`: full test suite passes.
- `./mvnw -Psourcecheck -Dcheckstyle.failOnViolation=true -DskipTests -pl :camel-kafka-connector-model -pl :camel-kafka-connector-generator-maven-plugin -pl :camel-kafka-connector clean install`
  — the exact step CI fails on — BUILD SUCCESS.