### PR TITLE
Fix #1806: apply camel.remove.headers.pattern before the sink route stages

### DIFF
--- a/core/src/main/java/org/apache/camel/kafkaconnector/CamelSinkTask.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/CamelSinkTask.java
@@ -135,6 +135,7 @@ public class CamelSinkTask extends SinkTask {
             }
 
             cms = CamelKafkaConnectMain.builder(LOCAL_URL, sinkKamelet)
+                .withRemoveHeadersFirst(true)
                 .withProperties(actualProps)
                 .withUnmarshallDataFormat(unmarshaller)
                 .withMarshallDataFormat(marshaller)

--- a/core/src/main/java/org/apache/camel/kafkaconnector/utils/CamelKafkaConnectMain.java
+++ b/core/src/main/java/org/apache/camel/kafkaconnector/utils/CamelKafkaConnectMain.java
@@ -116,6 +116,7 @@ public class CamelKafkaConnectMain extends SimpleMain {
         private int idempotentRepositoryKafkaMaxCacheSize;
         private int idempotentRepositoryKafkaPollDuration;
         private String headersExcludePattern;
+        private boolean removeHeadersFirst;
         private boolean dumpRoutes = true;
 
         public Builder(String from, String to) {
@@ -210,6 +211,23 @@ public class CamelKafkaConnectMain extends SimpleMain {
 
         public Builder withHeadersExcludePattern(String headersExcludePattern) {
             this.headersExcludePattern = headersExcludePattern;
+            return this;
+        }
+
+        /**
+         * Controls where the header-removal stage sits in the route.
+         *
+         * On the sink path record headers are mapped onto the exchange by {@code CamelSinkTask.put} *before* the
+         * exchange enters the route, so the stage must run first for {@code camel.remove.headers.pattern} to keep
+         * those headers away from the marshalling, aggregation and idempotency stages.
+         *
+         * On the source path headers arrive from the Camel consumer and are mapped onto the produced record after
+         * the route has run, so the stage stays last and the intermediate stages keep seeing them.
+         *
+         * @param removeHeadersFirst true for the sink direction, false (the default) for the source direction.
+         */
+        public Builder withRemoveHeadersFirst(boolean removeHeadersFirst) {
+            this.removeHeadersFirst = removeHeadersFirst;
             return this;
         }
 
@@ -365,6 +383,9 @@ public class CamelKafkaConnectMain extends SimpleMain {
 
                     //creating the actual route
                     ProcessorDefinition<?> rd = from(from);
+                    if (removeHeadersFirst) {
+                        rd = rd.kamelet("ckcRemoveHeader");
+                    }
                     if (!ObjectHelper.isEmpty(marshallDataFormat)) {
                         rd = rd.kamelet("ckcMarshal");
                     }
@@ -377,7 +398,9 @@ public class CamelKafkaConnectMain extends SimpleMain {
                     if (idempotencyEnabled) {
                         rd = rd.kamelet("ckcIdempotent");
                     }
-                    rd = rd.kamelet("ckcRemoveHeader");
+                    if (!removeHeadersFirst) {
+                        rd = rd.kamelet("ckcRemoveHeader");
+                    }
                     rd.toD(to);
                 }
             });

--- a/core/src/test/java/org/apache/camel/kafkaconnector/utils/RemoveHeadersOrderTest.java
+++ b/core/src/test/java/org/apache/camel/kafkaconnector/utils/RemoveHeadersOrderTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.kafkaconnector.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.AggregationStrategy;
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.kafkaconnector.CamelConnectorConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * camel.remove.headers.pattern is the documented mitigation for untrusted headers reaching the route. On the sink
+ * path the headers are mapped onto the exchange before it enters the route, so the removal stage has to run before
+ * the stages that consume them; on the source path they arrive from the consumer and are read off the exchange after
+ * the route, so it stays last.
+ */
+public class RemoveHeadersOrderTest {
+
+    private static final String STRIPPED_HEADER = "CamelExecCommandExecutable";
+
+    private RecordingAggregationStrategy runRouteWith(boolean removeHeadersFirst) throws Exception {
+        Map<String, String> props = new HashMap<>();
+        props.put(CamelConnectorConfig.CAMEL_CONNECTOR_REMOVE_HEADERS_PATTERN_CONF, STRIPPED_HEADER);
+
+        DefaultCamelContext context = new DefaultCamelContext();
+        RecordingAggregationStrategy strategy = new RecordingAggregationStrategy();
+        context.getRegistry().bind(CamelConnectorConfig.CAMEL_CONNECTOR_AGGREGATE_NAME, strategy);
+
+        CamelKafkaConnectMain cms = CamelKafkaConnectMain.builder("direct://start", "log://end")
+            .withProperties(props)
+            .withHeadersExcludePattern(STRIPPED_HEADER)
+            .withAggregationSize(1)
+            .withAggregationTimeout(1000L)
+            .withRemoveHeadersFirst(removeHeadersFirst)
+            .build(context);
+
+        cms.start();
+        try {
+            cms.getProducerTemplate().sendBodyAndHeader("direct://start", "payload", STRIPPED_HEADER, "/bin/sh");
+        } finally {
+            cms.stop();
+        }
+        return strategy;
+    }
+
+    @Test
+    public void testSinkDirectionStripsHeadersBeforeTheAggregationStage() throws Exception {
+        RecordingAggregationStrategy strategy = runRouteWith(true);
+
+        assertNull(strategy.seenHeaderValue,
+                "camel.remove.headers.pattern must strip the header before the aggregation stage sees it on the "
+                        + "sink path, but the strategy saw: " + strategy.seenHeaderValue);
+    }
+
+    @Test
+    public void testSourceDirectionKeepsHeadersUntilTheEndOfTheRoute() throws Exception {
+        RecordingAggregationStrategy strategy = runRouteWith(false);
+
+        assertEquals("/bin/sh", strategy.seenHeaderValue,
+                "on the source path the stripping stage stays last, so intermediate stages still see the header");
+    }
+
+    private static final class RecordingAggregationStrategy implements AggregationStrategy {
+
+        private volatile Object seenHeaderValue;
+
+        @Override
+        public Exchange aggregate(Exchange oldExchange, Exchange newExchange) {
+            if (newExchange != null) {
+                seenHeaderValue = newExchange.getMessage().getHeader(STRIPPED_HEADER);
+            }
+            return newExchange;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1806.

## What

The route was assembled with `ckcRemoveHeader` appended last, for both directions:

```
from(from) -> [ckcMarshal] -> [ckcUnMarshal] -> [ckcAggregator] -> [ckcIdempotent] -> ckcRemoveHeader -> toD(to)
```

That is right for the **source** direction — headers arrive from the Camel consumer and are mapped onto
the produced record after the route has run, so stripping just before the end is what you want.

It is wrong for the **sink** direction. `CamelSinkTask.put()` maps `CamelHeader.`-prefixed record
headers onto the exchange *before* the exchange enters the route, so every stage runs before the
removal does. With `camel.remove.headers.pattern` set, the idempotency expression, a configured
`AggregationStrategy` and the data formats all still saw the headers the operator asked to strip — so
the documented mitigation did not do what
`docs/modules/ROOT/pages/user-guide/remove-headers.adoc` says it does.

## Fix

The builder had no way to know which direction it was assembling. Added
`withRemoveHeadersFirst(boolean)`, set by `CamelSinkTask`; the stage now runs first on the sink path
and stays last on the source path.

The builder default is `false`, i.e. the previous placement, so anyone driving
`CamelKafkaConnectMain.Builder` directly is unaffected. Only the sink task opts in.

## Tests

`RemoveHeadersOrderTest` observes what the mid-route stages actually see, by binding an
`AggregationStrategy` that records the header value it receives. Against the old ordering, with
`camel.remove.headers.pattern=CamelExecCommandExecutable` explicitly configured:

```
camel.remove.headers.pattern must strip the header before the aggregation stage sees it on the
sink path, but the strategy saw: /bin/sh   ==> expected: <null> but was: </bin/sh>
```

The paired source-direction test asserts the strategy *does* still see the header, pinning the
existing source behaviour so this change cannot silently alter it.

## Verification

- `core`: full suite passes.
- `./mvnw -Psourcecheck -Dcheckstyle.failOnViolation=true checkstyle:checkstyle`: BUILD SUCCESS.
- Full reactor build from the repository root with the whole test suite (`./mvnw clean install`):
  BUILD SUCCESS, 24 test runs, no failures.

## Related

The issue also notes a gap this PR does not close: `removeHeaders` only acts on message headers, while
`CamelSinkTask.put()` also maps `CamelProperty.`-prefixed record headers into **exchange properties**
(`camel.map.properties`, default `true`), and there is no `camel.remove.properties.pattern`
counterpart. That needs a new option rather than a reordering, so it seemed worth deciding separately —
it is part of the discussion in #1807.