### PR TITLE
Fix #1804: harden CI workflows and pin the build toolchain

### DIFF
--- a/.github/workflows/asf-snapshots-deploy.yml
+++ b/.github/workflows/asf-snapshots-deploy.yml
@@ -25,6 +25,9 @@ on:
     - cron:  '0 1 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -32,14 +35,14 @@ jobs:
       matrix:
         java: [ '17' ]
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5.4.0
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Cache Maven Repository
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -52,17 +55,17 @@ jobs:
         java: [ '17' ]
     needs: build
     if: github.ref == 'refs/heads/main'
-    env:
-      NEXUS_DEPLOY_USERNAME: ${{ secrets.NEXUS_USER }}
-      NEXUS_DEPLOY_PASSWORD: ${{ secrets.NEXUS_PW }}
     steps:
-    - uses: actions/checkout@v7.0.0
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v5.4.0
+      uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
     - name: Deploy to ASF Snapshots Repository
+      env:
+        NEXUS_DEPLOY_USERNAME: ${{ secrets.NEXUS_USER }}
+        NEXUS_DEPLOY_PASSWORD: ${{ secrets.NEXUS_PW }}
       run: |
         ./mvnw ${MAVEN_ARGS} \
         -U -B -e -fae -Dnoassembly -Dmaven.compiler.fork=true -Pdeploy -Dmaven.test.skip.exec=true \

--- a/.github/workflows/automatic-changelog-update.yml
+++ b/.github/workflows/automatic-changelog-update.yml
@@ -23,6 +23,9 @@ on:
     - cron:  '0 3 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   generate_changelog:
     runs-on: ubuntu-latest
@@ -30,7 +33,7 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.repository == 'apache/camel-kafka-connector'
     steps:
       - name: "Checkout camel-kafka-connector"
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/automatic-sync-camel-main.yml
+++ b/.github/workflows/automatic-sync-camel-main.yml
@@ -25,6 +25,10 @@ on:
     # Run at 2 AM every day
     - cron:  '0 2 * * *'
   workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   build:
     name: Sync Camel Kafka Connector main Branch with latest Camel main
@@ -34,18 +38,18 @@ jobs:
         java: [ '17' ]
     steps:
       - name: Checkout Camel project
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: apache/camel
           ref: main
           path: camel
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5.4.0
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Cache local Maven repository
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -58,7 +62,7 @@ jobs:
             clean install
         working-directory: ${{ github.workspace }}/camel
       - name: Checkout camel-kafka-connector project
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: main
           fetch-depth: 0
@@ -96,13 +100,13 @@ jobs:
             -pl '!:camel-kafka-connector-generator-maven-plugin' \
             clean test
       - name: archive logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: test-logs-java-${{ matrix.java }}
           path: tests/**/target/tests.log
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           base: main
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -22,13 +22,17 @@ on:
       - closed
       - labeled
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   backport:
     runs-on: ubuntu-latest
     name: Backport
     steps:
       - name: "Checkout camel-kafka-connector"
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -34,6 +34,9 @@ on:
       - Jenkinsfile.*
       - NOTICE.txt
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -46,9 +49,9 @@ jobs:
           - java: '21'
             experimental: true
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5.4.0
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -88,7 +91,7 @@ jobs:
             -pl '!:camel-kafka-connector-generator-maven-plugin' \
             clean test
       - name: Archive logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: test-logs-java-${{ matrix.java }}

--- a/.github/workflows/daily-java-next.yml
+++ b/.github/workflows/daily-java-next.yml
@@ -26,6 +26,9 @@ on:
     - cron:  '0 2 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -33,9 +36,9 @@ jobs:
       matrix:
         java: [ '21' ]
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5.4.0
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -75,7 +78,7 @@ jobs:
             -pl '!:camel-kafka-connector-generator-maven-plugin' \
             clean test
       - name: Archive logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: test-logs-java-${{ matrix.java }}

--- a/.github/workflows/depsreview.yaml
+++ b/.github/workflows/depsreview.yaml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5

--- a/.github/workflows/maven-it.yaml
+++ b/.github/workflows/maven-it.yaml
@@ -34,6 +34,9 @@ on:
       - NOTICE.txt
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -46,9 +49,9 @@ jobs:
           - java: '21'
             experimental: true
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5.4.0
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -74,7 +77,7 @@ jobs:
             -pl :camel-kafka-connector-generator-maven-plugin \
             clean verify
       - name: Archive test results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ failure() }}
         with:
           name: maven-it-java-${{ matrix.java }}

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -17,3 +17,4 @@
 wrapperVersion=3.3.2
 distributionType=only-script
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionSha256Sum=4ec3f26fb1a692473aea0235c300bd20f0f9fe741947c82c1234cefd76ac3a3c

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     </mailingLists>
 
     <scm>
-        <connection>scm:git:http://gitbox.apache.org/repos/asf/camel-kafka-connector.git</connection>
+        <connection>scm:git:https://gitbox.apache.org/repos/asf/camel-kafka-connector.git</connection>
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/camel-kafka-connector.git</developerConnection>
         <url>https://gitbox.apache.org/repos/asf?p=camel-kafka-connector.git;a=summary</url>
         <tag>HEAD</tag>


### PR DESCRIPTION
Fixes #1804. Four independent gaps, small enough to do together.

## 1. Least-privilege token permissions

Only `depsreview.yaml` declared a `permissions:` block, so every other workflow ran with the
repository-default `GITHUB_TOKEN` scope. Declared per workflow, based on what each actually does:

| Workflow | Permissions | Why |
|---|---|---|
| `ci-build.yml`, `daily-java-next.yml`, `maven-it.yaml` | `contents: read` | build and test only |
| `asf-snapshots-deploy.yml` | `contents: read` | publishes to Nexus, not to GitHub |
| `automatic-changelog-update.yml` | `contents: write` | pushes to `main` |
| `automatic-sync-camel-main.yml`, `backport.yml` | `contents: write`, `pull-requests: write` | open pull requests |

## 2. Immutable action references

Every `uses:` was a mutable tag. Pinned all six to full commit SHAs with the version in a trailing
comment, matching what the two in-repo composite actions already get from SHA-locked submodules.
Dependabot keeps updating SHA-pinned actions, so this does not freeze them.

```
actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
```

Worth noting: `actions/dependency-review-action@v5` was not a tag at all — `v5` is a **branch** on
that repository, which is looser still than a tag.

## 3. Deploy credential scope

`NEXUS_DEPLOY_USERNAME` / `NEXUS_DEPLOY_PASSWORD` were job-level `env:` in
`asf-snapshots-deploy.yml`, so they were in the environment of every step in the job, including
`checkout` and `setup-java`. Moved onto the deploy step, which is the only one that needs them.

## 4. Build toolchain integrity

`.mvn/wrapper/maven-wrapper.properties` pinned `distributionUrl` but had no
`distributionSha256Sum`, so `mvnw` skipped verification — `Cannot checksum, no distributionSha256Sum
set` — on every build path: all workflows, the Jenkinsfiles, and `release-utils/release.sh`.

`repo.maven.apache.org` publishes only a `.sha512` for this artifact, so I verified the distribution
against that published SHA-512 first and derived the SHA-256 from the same verified bytes:

```
published sha512: 8beac8d1...4c4418ba
local     sha512: 8beac8d1...4c4418ba   MATCHES
derived   sha256: 4ec3f26fb1a692473aea0235c300bd20f0f9fe741947c82c1234cefd76ac3a3c
```

Confirmed it is enforced fail-closed, by pointing a fresh `MAVEN_USER_HOME` at a deliberately wrong
value:

```
Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised.
```

and confirmed a clean download against the real value succeeds.

## Also

`scm/connection` in `pom.xml` used `http://`; `developerConnection` on the next line already used
`https://`.

## Verification

- All eight workflow files parse as YAML with the intended `permissions` values.
- Full reactor build from the repository root (`./mvnw clean install -DskipTests`): BUILD SUCCESS.

## Not included

`backport.yml` resolves `./.github/actions/backport` from the pull request's merge commit. Since the
trigger is `pull_request` (not `pull_request_target`), a fork PR gets a read-only token and no
secrets, so the exposure is limited — and changing it means restructuring how that action is
resolved. Left out of this PR deliberately; happy to follow up if you want it.