### PR TITLE
chore: assert the ckcMarshal route template still marshals

### DIFF
--- a/core/src/test/java/org/apache/camel/kafkaconnector/DataFormatTest.java
+++ b/core/src/test/java/org/apache/camel/kafkaconnector/DataFormatTest.java
@@ -174,4 +174,34 @@ public class DataFormatTest {
         assertFalse(hl7dfLoaded.isValidate());
         cms.stop();
     }
+
+    @Test
+    public void testMarshalRouteActuallyMarshals() throws Exception {
+        // Symmetric guard for testUnmarshalRouteActuallyUnmarshals: nothing asserted that ckcMarshal still
+        // applies marshal, so the mistake fixed in #1795 could be reintroduced in the other template unnoticed.
+        Map<String, String> props = new HashMap<>();
+        props.put("camel.source.url", "direct://test");
+        props.put("topics", "mytopic");
+        props.put("camel.source.marshal", "syslog");
+
+        DefaultCamelContext dcc = new DefaultCamelContext();
+        CamelKafkaConnectMain cms = CamelKafkaConnectMain.builder("direct://start", "log://test")
+            .withProperties(props)
+            .withMarshallDataFormat("syslog")
+            .build(dcc);
+
+        dcc.getRegistry().bind("syslog", new SyslogDataFormat());
+
+        cms.start();
+        ProducerTemplate template = dcc.createProducerTemplate();
+        SyslogMessage message = new SyslogMessage();
+        message.setHostname("mymachine");
+        message.setLogMessage("su root failed for lonvick");
+        Object result = template.requestBody("direct://start", message);
+
+        // marshal turns the SyslogMessage into its wire form; unmarshal would have thrown instead
+        assertNotNull(result);
+        assertFalse(result instanceof SyslogMessage, "camel.*.marshal must encode, not decode: got " + result);
+        cms.stop();
+    }
 }


### PR DESCRIPTION
Small follow-up to #1796 / #1795.

## Why

#1796 fixed `ckcUnMarshal` calling `.marshal()` and added `testUnmarshalRouteActuallyUnmarshals` to
guard that direction. Nothing asserts the same for `ckcMarshal`, so the symmetric mistake — flipping
the *other* template to `.unmarshal()` — would pass CI unnoticed. The two templates sit next to each
other and the original bug was a copy-paste between them, so it is worth pinning both ends.

## What

Adds `testMarshalRouteActuallyMarshals`: a `SyslogMessage` sent through a route built with
`camel.source.marshal` must come back encoded, not as a `SyslogMessage`.

Confirmed it discriminates — flipping `ckcMarshal` to `.unmarshal("{{marshal}}")` fails it:

```
DataFormatTest.testMarshalRouteActuallyMarshals:200 » CamelExecution Exception occurred during
execution on the exchange
```

## Verification

- `core`: 121 tests pass.
- `./mvnw -Psourcecheck -Dcheckstyle.failOnViolation=true checkstyle:checkstyle`: BUILD SUCCESS.
- Full reactor build from the repository root (`./mvnw clean install -DskipTests`): BUILD SUCCESS.

Test-only; no production code touched.