### PR TITLE
Fix #1805: keep the release password off the command line and stop re-pointing the tag

### DIFF
--- a/release-utils/release.sh
+++ b/release-utils/release.sh
@@ -39,10 +39,12 @@ defaultReleaseTag=$prefix$releaseV
 read -r -p "Enter release tag: [$defaultReleaseTag]" releaseTag
 export RELEASE_TAG=${releaseTag:-$defaultReleaseTag}
 
-read -r -p "Enter apache username: " user
-export APACHE_USER=$user
-
-export APACHE_PASS=`$DIR/scripts/askpass_stars.sh Enter apache password: `
+# SCM credentials are no longer passed to Maven. maven-release-plugin would receive them as
+# -Dusername/-Dpassword, which puts the password in the process table for the whole build and in the
+# shell history. git is left to authenticate on its own instead, so configure one of:
+#   - an SSH remote for gitbox, or
+#   - a git credential helper for https://gitbox.apache.org
+# before running this script.
 
 defaultGpgProfile=gpg
 read -r -p "Enter the maven gpg profile: [$defaultGpgProfile]" gpgProfile
@@ -70,6 +72,11 @@ done
 if [ "$CHECKOUT_RELEASE_TAG" == Y ]; then
     git checkout -b "$RELEASE_BRANCH"
 fi
-./mvnw -Prelease -P"$GPG_PROFILE" -DreleaseVersion="$RELEASE_VERSION" -DdevelopmentVersion="$NEXT_VERSION" -Dtag="$RELEASE_TAG" -Dusername="$APACHE_USER" -Dpassword="$APACHE_PASS" release:prepare && \
-git checkout "$RELEASE_TAG" && git add ./*.json && git commit -m"[after release perform chore]: regen catalog descriptors with new version" && git tag -f "$RELEASE_TAG" && git push -f origin "$RELEASE_TAG" && git checkout "$RELEASE_BRANCH" && \
-./mvnw -Prelease -Pgpg -Dusername="$APACHE_USER" -Dpassword="$APACHE_PASS" release:perform
+# Prepare the release locally. pushChanges=false keeps release:prepare from publishing the branch
+# and the tag, so the catalog descriptors below can be folded into the tagged commit before anything
+# reaches the remote. The tag is therefore pushed exactly once, in its final state, and never
+# re-pointed.
+./mvnw -Prelease -P"$GPG_PROFILE" -DreleaseVersion="$RELEASE_VERSION" -DdevelopmentVersion="$NEXT_VERSION" -Dtag="$RELEASE_TAG" -DpushChanges=false release:prepare && \
+git checkout "$RELEASE_TAG" && git add ./*.json && git commit -m"[after release perform chore]: regen catalog descriptors with new version" && git tag -f "$RELEASE_TAG" && git checkout "$RELEASE_BRANCH" && \
+git push origin "$RELEASE_BRANCH" && git push origin "$RELEASE_TAG" && \
+./mvnw -Prelease -Pgpg release:perform


### PR DESCRIPTION
Fixes #1805.

## :warning: Not tested end to end

Exercising this means cutting a real release, which I could not do. Everything below is reasoned from
the script and the plugin's documented behaviour, and the script's syntax is checked (`bash -n`), but
**please validate before trusting it** — `release:prepare` supports a dry run:

```sh
./mvnw -Prelease -Pgpg -DreleaseVersion=X.Y.Z -DdevelopmentVersion=X.Y.Z+1-SNAPSHOT \
       -Dtag=camel-kafka-connector-X.Y.Z -DpushChanges=false -DdryRun=true release:prepare
```

If either change does not suit how you actually run releases, say so and I will adjust or drop it.

## 1. The password no longer goes on a command line

The script prompted for the Apache password and passed it to Maven as `-Dpassword="$APACHE_PASS"`,
which puts it in the process table for the whole build and in shell history.

There is no way to hand `maven-release-plugin` that value without it landing on a command line — `-D`
user properties are the only channel it reads. So this stops passing SCM credentials through Maven at
all and lets git authenticate on its own, which is what actually performs the push.

**This changes what you need configured before a release:** either an SSH remote for gitbox, or a git
credential helper for `https://gitbox.apache.org`. The script now says so at the point where it used
to prompt. `-Dusername` went with it, since it is useless alone.

`release-utils/scripts/askpass_stars.sh` is now unused. I left it in place rather than delete it, in
case you call it from somewhere outside this repository.

## 2. The release tag is pushed once and never re-pointed

Previously:

```sh
./mvnw ... release:prepare && \                      # creates AND pushes the tag
git checkout "$RELEASE_TAG" && git add ./*.json && git commit -m"..." && \
git tag -f "$RELEASE_TAG" && git push -f origin "$RELEASE_TAG" && ...
```

so a published tag changed the commit it pointed at. Anyone who fetched
`camel-kafka-connector-X.Y.Z` before the force-push has a different tree from anyone who fetched it
after.

The catalog descriptors embed the released version, which only exists once `release:prepare` has
rewritten the poms — so they genuinely cannot be generated beforehand, which is presumably why it was
written this way. The fix is to keep `release:prepare` from publishing at all:

```sh
./mvnw ... -DpushChanges=false release:prepare && \  # local only
git checkout "$RELEASE_TAG" && git add ./*.json && git commit -m"..." && \
git tag -f "$RELEASE_TAG" && git checkout "$RELEASE_BRANCH" && \
git push origin "$RELEASE_BRANCH" && git push origin "$RELEASE_TAG" && \
./mvnw -Prelease -Pgpg release:perform
```

`git tag -f` still runs, but only against the local tag, before anything has been published. The
branch and the tag are then pushed once each, and `release:perform` runs after the tag is on the
remote, which is what it needs to check out.

## Checked

- `bash -n release-utils/release.sh` passes.
- No remaining reference to `APACHE_USER` / `APACHE_PASS` anywhere in the repository.
- No other script under `release-utils/` uses `-Dpassword` or a force push, so this is the only
  occurrence of either pattern.